### PR TITLE
Allow running more than one process of travis-logs

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,7 @@
 logs: ./bin/logs
+logs1: LOGS_QUEUE=1 ./bin/logs
+logs2: LOGS_QUEUE=2 ./bin/logs
+logs3: LOGS_QUEUE=3 ./bin/logs
+logs4: LOGS_QUEUE=4 ./bin/logs
+logs5: LOGS_QUEUE=5 ./bin/logs
 

--- a/spec/logs_spec.rb
+++ b/spec/logs_spec.rb
@@ -27,6 +27,19 @@ describe Travis::Logs do
       end
       app.send(:subscribe)
     end
+
+    describe 'with queue_number present' do
+      it 'adds queue_number to queue_name' do
+        app.stubs :queue_number => 6
+
+        Travis::Amqp::Consumer.expects(:jobs).with('logs-6').returns(consumer)
+        0.upto(2) do |shard|
+          Travis::Amqp::Consumer.expects(:jobs).with("logs-6.#{shard}").returns(consumer)
+        end
+
+        app.send(:subscribe)
+      end
+    end
   end
 
   describe 'receive' do


### PR DESCRIPTION
I've checked this code on staging and it seems to work correctly. All you have to do is add `logging_channel` config value to a worker and set it to one of the queues (e.g. `logging_channel: 'reporting.jobs.logs-1'`).

I don't know how to get the process name, so instead I declared 5 additional processes in Procfile. Each of those processes should be scaled to either 1 or 0 - that way we can control the number of processes and ensure that only one process is running on each queue (big thanks for @joshk for the idea!).

If additional processes are not running, the `logs` process defaults to the current queue name, so if you think that it looks good, we could deploy it on production and test with adding only one additional process and then changing the config for the least busy worker to hit the new queue.
