### PR TITLE
Set the Postgres application name when connecting

### DIFF
--- a/lib/travis/logs/helpers/database.rb
+++ b/lib/travis/logs/helpers/database.rb
@@ -13,6 +13,7 @@ module Travis
           db.logger = Travis.logger unless Travis::Logs.config.env == 'production'
           db.timezone = :utc
           db.test_connection
+          db << "SET application_name = 'logs'"
           db
         end
 


### PR DESCRIPTION
This should improve the logging and help identify queries and connections coming from this app.
