### PR TITLE
Add log removal data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_script:
   - psql -c "CREATE DATABASE travis_test;" -U postgres
   - cp config/travis.example.yml config/travis.yml
   - bundle exec rake db:setup
+  - bundle exec rake db:add_log_remove_data
 script: bundle exec rspec spec
 matrix:
   allow_failures:

--- a/Rakefile
+++ b/Rakefile
@@ -43,4 +43,12 @@ namespace :db do
     db.drop_table(:logs)
     db.drop_table(:log_parts)
   end
+
+  task :add_log_remove_data, [:version] do |t, args|
+    db = Travis::Logs::Helpers::Database.create_sequel
+    db.alter_table(:logs) do
+      add_column :removed_by, :integer
+      add_column :removed_at, DateTime
+    end
+  end
 end


### PR DESCRIPTION
This is required for the new log removal feature. There is an existing PR (https://github.com/travis-ci/travis-core/pull/353), but it will most likely be reworked.

Ideally, we should be using [Sequel migrations](http://sequel.jeremyevans.net/rdoc/files/doc/migration_rdoc.html) to manage migrations here, but I get the following exception when I try to dump the current schema:

```
$ bx sequel -d postgres://localhost/travis_development
Error: Sequel::AdapterNotFound: LoadError: no such file to load -- pgorg/jruby/RubyKernel.java:1082:in `require'
```

So, for the time being, manage stuff with a very kludgy db alteration.
