### PR TITLE
Change "clear log content" API endpoint to "set log content"

### DIFF
--- a/lib/travis/logs/app.rb
+++ b/lib/travis/logs/app.rb
@@ -59,7 +59,7 @@ module Travis
         status 204
       end
 
-      post "/logs/:id/clear" do
+      put "/logs/:job_id" do
         if ENV["AUTH_TOKEN"].strip.empty?
           raise "authentication token is not set"
         end
@@ -68,13 +68,16 @@ module Travis
           halt 403
         end
 
-        log_id = Integer(params[:id])
+        job_id = Integer(params[:job_id])
 
-        if database.log_for_id(log_id).nil?
+        log = database.log_for_job_id(job_id)
+        if log.nil?
           halt 404
         end
 
-        database.clear_log(log_id)
+        request.body.rewind
+        database.set_log_content(log[:id], request.body.read)
+
         status 204
       end
     end

--- a/lib/travis/logs/app.rb
+++ b/lib/travis/logs/app.rb
@@ -70,10 +70,7 @@ module Travis
 
         job_id = Integer(params[:job_id])
 
-        log = database.log_for_job_id(job_id)
-        if log.nil?
-          halt 404
-        end
+        log = database.log_for_job_id(job_id) || database.create_log(job_id)
 
         request.body.rewind
         database.set_log_content(log[:id], request.body.read)

--- a/lib/travis/logs/helpers/database.rb
+++ b/lib/travis/logs/helpers/database.rb
@@ -88,9 +88,9 @@ module Travis
           @db.call(:delete_log_parts, log_id: log_id)
         end
 
-        def clear_log(log_id)
+        def set_log_content(log_id, content)
           delete_log_parts(log_id)
-          @db[:logs].where(id: log_id).update(content: "", aggregated_at: nil, archived_at: nil, archive_verified: nil)
+          @db[:logs].where(id: log_id).update(content: content, aggregated_at: nil, archived_at: nil, archive_verified: nil)
         end
 
         AGGREGATEABLE_SELECT_SQL = <<-SQL.squish

--- a/lib/travis/logs/helpers/database.rb
+++ b/lib/travis/logs/helpers/database.rb
@@ -90,7 +90,7 @@ module Travis
 
         def set_log_content(log_id, content)
           delete_log_parts(log_id)
-          @db[:logs].where(id: log_id).update(content: content, aggregated_at: nil, archived_at: nil, archive_verified: nil)
+          @db[:logs].where(id: log_id).update(content: content, aggregated_at: nil, archived_at: nil, archive_verified: nil, updated_at: Time.now.utc)
         end
 
         AGGREGATEABLE_SELECT_SQL = <<-SQL.squish

--- a/lib/travis/logs/helpers/database.rb
+++ b/lib/travis/logs/helpers/database.rb
@@ -90,7 +90,7 @@ module Travis
 
         def set_log_content(log_id, content)
           delete_log_parts(log_id)
-          @db[:logs].where(id: log_id).update(content: content, aggregated_at: nil, archived_at: nil, archive_verified: nil, updated_at: Time.now.utc)
+          @db[:logs].where(id: log_id).update(content: content, aggregated_at: Time.now.utc, archived_at: nil, archive_verified: nil, updated_at: Time.now.utc)
         end
 
         AGGREGATEABLE_SELECT_SQL = <<-SQL.squish

--- a/spec/integration/app_spec.rb
+++ b/spec/integration/app_spec.rb
@@ -116,10 +116,13 @@ module Travis::Logs
         expect(response.status).to be == 204
       end
 
-      it "returns 404 if the log doesn't exist" do
+      it "creates the log if it doesn't exist" do
         header "Authorization", "token #{@auth_token}"
+
+        expect(database).to receive(:create_log).with(@job_id+1).and_return({ id: @log_id+1, job_id: @job_id+1, content: "" })
+
         response = put "/logs/#{@job_id+1}"
-        expect(response.status).to be == 404
+        expect(response.status).to be == 204
       end
 
       it "tells the database to set the log content" do

--- a/spec/integration/database_spec.rb
+++ b/spec/integration/database_spec.rb
@@ -254,20 +254,20 @@ module Travis::Logs::Helpers
       end
     end
 
-    describe "#clear_log" do
+    describe "#set_log_content" do
       before do
         @log_id = sequel[:logs].insert(content: "this is a test", aggregated_at: Time.now.utc)
       end
 
       it "clears out the content" do
-        database.clear_log(@log_id)
+        database.set_log_content(@log_id, "hello world")
 
         content = sequel[:logs].where(id: @log_id).get(:content)
-        expect(content).to be == ""
+        expect(content).to be == "hello world"
       end
 
       it "nils out the aggregated_at time" do
-        database.clear_log(@log_id)
+        database.set_log_content(@log_id, "hello world")
 
         aggregated_at = sequel[:logs].where(id: @log_id).get(:aggregated_at)
         expect(aggregated_at).to be_nil

--- a/spec/integration/database_spec.rb
+++ b/spec/integration/database_spec.rb
@@ -266,11 +266,11 @@ module Travis::Logs::Helpers
         expect(content).to be == "hello world"
       end
 
-      it "nils out the aggregated_at time" do
+      it "sets the aggregated_at time" do
         database.set_log_content(@log_id, "hello world")
 
         aggregated_at = sequel[:logs].where(id: @log_id).get(:aggregated_at)
-        expect(aggregated_at).to be_nil
+        expect(aggregated_at).to_not be_nil
       end
     end
   end


### PR DESCRIPTION
Clearing a log can be implemented by setting the log to the empty string. This API endpoint is more versatile, though, and can be used for things like writing an error to the logs.

The new endpoint also takes the job ID instead of the log ID, since the log ID is an internal implementation detail that shouldn't really leak outside of the logs app.