### PR TITLE
Aggregate a smaller number of logs per aggregate run

### DIFF
--- a/lib/travis/logs/config.rb
+++ b/lib/travis/logs/config.rb
@@ -9,7 +9,7 @@ module Travis
               s3:            { hostname: "archive.travis-ci.org", access_key_id: '', secret_access_key: '', acl: :public_read },
               pusher:        { app_id: 'app-id', key: 'key', secret: 'secret', secure: false },
               sidekiq:       { namespace: 'sidekiq', pool_size: 3 },
-              logs:          { archive: true, purge: false, threads: 10, intervals: { vacuum: 10, regular: 180, force: 3 * 60 * 60, purge: 6 } },
+              logs:          { archive: true, purge: false, threads: 10, per_aggregate_limit: 500, intervals: { vacuum: 10, regular: 180, force: 3 * 60 * 60, purge: 6 } },
               redis:         { url: 'redis://localhost:6379' },
               metrics:       { reporter: 'librato' },
               ssl:           { },

--- a/lib/travis/logs/helpers/database.rb
+++ b/lib/travis/logs/helpers/database.rb
@@ -104,14 +104,15 @@ module Travis
         end
 
         AGGREGATEABLE_SELECT_SQL = <<-SQL.squish
-          SELECT DISTINCT log_id
+          SELECT log_id
             FROM log_parts
            WHERE (created_at <= NOW() - interval '? seconds' AND final = ?)
               OR  created_at <= NOW() - interval '? seconds'
+           LIMIT ?
         SQL
 
-        def aggregatable_log_parts(regular_interval, force_interval)
-          @db[AGGREGATEABLE_SELECT_SQL, regular_interval, true, force_interval].map(:log_id)
+        def aggregatable_log_parts(regular_interval, force_interval, limit)
+          @db[AGGREGATEABLE_SELECT_SQL, regular_interval, true, force_interval, limit].map(:log_id).uniq
         end
 
         AGGREGATE_PARTS_SELECT_SQL = <<-SQL.squish

--- a/lib/travis/logs/services/aggregate_logs.rb
+++ b/lib/travis/logs/services/aggregate_logs.rb
@@ -83,11 +83,15 @@ module Travis
           end
 
           def aggregateable_ids
-            database.aggregatable_log_parts(intervals[:regular], intervals[:force])
+            database.aggregatable_log_parts(intervals[:regular], intervals[:force], per_aggregate_limit).uniq
           end
 
           def intervals
             Travis.config.logs.intervals
+          end
+
+          def per_aggregate_limit
+            Travis.config.logs.per_aggregate_limit
           end
 
           def transaction(&block)

--- a/spec/integration/database_spec.rb
+++ b/spec/integration/database_spec.rb
@@ -161,31 +161,31 @@ module Travis::Logs::Helpers
       end
 
       it "includes finished logs older than the regular interval" do
-        log_ids = database.aggregatable_log_parts(60  *  30, 60 * 60 * 12)
+        log_ids = database.aggregatable_log_parts(60  *  30, 60 * 60 * 12, 500)
 
         expect(log_ids).to include(2)
       end
 
       it "includes unfinished logs older than the forced interval" do
-        log_ids = database.aggregatable_log_parts(60  *  30, 60 * 60 * 12)
+        log_ids = database.aggregatable_log_parts(60  *  30, 60 * 60 * 12, 500)
 
         expect(log_ids).to include(1)
       end
 
       it "doesn't include finished logs newer than the regular interval" do
-        log_ids = database.aggregatable_log_parts(60  *  60 * 2, 60 * 60 * 12)
+        log_ids = database.aggregatable_log_parts(60  *  60 * 2, 60 * 60 * 12, 500)
 
         expect(log_ids).not_to include(2)
       end
 
       it "doesn't include unfinished logs newer than the forced interval" do
-        log_ids = database.aggregatable_log_parts(60  *  30, 60 * 60 * 24 * 2)
+        log_ids = database.aggregatable_log_parts(60  *  30, 60 * 60 * 24 * 2, 500)
 
         expect(log_ids).not_to include(1)
       end
 
       it "only includes each log_id once" do
-        log_ids = database.aggregatable_log_parts(60  *  30, 60 * 60 * 12)
+        log_ids = database.aggregatable_log_parts(60  *  30, 60 * 60 * 12, 500)
 
         expect(log_ids).to eq(log_ids.uniq)
       end


### PR DESCRIPTION
This means we don't have to do a full table scan each time, which is
slow when the table gets big.