### PR TITLE
aggregate: order by created_at

### DIFF
--- a/lib/travis/logs/helpers/database.rb
+++ b/lib/travis/logs/helpers/database.rb
@@ -108,6 +108,7 @@ module Travis
             FROM log_parts
            WHERE (created_at <= NOW() - interval '? seconds' AND final = ?)
               OR  created_at <= NOW() - interval '? seconds'
+        ORDER BY created_at ASC
            LIMIT ?
         SQL
 


### PR DESCRIPTION
This way the order that things are being aggregated in is going to be deterministic, starting with the oldest job.