### PR TITLE
Check for AMQPS protocol, enable ssl if so

### DIFF
--- a/lib/travis/logs/config.rb
+++ b/lib/travis/logs/config.rb
@@ -12,7 +12,11 @@ module Travis
         %w(1 yes on).include?(ENV['PG_DISABLE_SSL'].to_s.downcase)
       end
 
-      define  amqp:          { username: 'guest', password: 'guest', host: 'localhost', prefetch: 1 },
+      def self.amqp_ssl?
+        /^amqps:\/\//.match(ENV['RABBITMQ_URL']).size > 0
+      end
+
+      define  amqp:          { username: 'guest', password: 'guest', host: 'localhost', prefetch: 1, ssl: amqp_ssl? },
               logs_database: { adapter: 'postgresql', database: "travis_logs_#{env}", ssl: ssl?, encoding: 'unicode', min_messages: 'warning' },
               s3:            { hostname: "archive.travis-ci.org", access_key_id: '', secret_access_key: '', acl: :public_read },
               pusher:        { app_id: 'app-id', key: 'key', secret: 'secret', secure: false },

--- a/lib/travis/logs/config.rb
+++ b/lib/travis/logs/config.rb
@@ -13,7 +13,8 @@ module Travis
       end
 
       def self.amqp_ssl?
-        /^amqps:\/\//.match(ENV['RABBITMQ_URL']).size > 0
+        match = /^amqps:\/\//.match(ENV['RABBITMQ_URL'])
+        match && match.size > 0
       end
 
       define  amqp:          { username: 'guest', password: 'guest', host: 'localhost', prefetch: 1, ssl: amqp_ssl? },

--- a/lib/travis/logs/config.rb
+++ b/lib/travis/logs/config.rb
@@ -13,8 +13,7 @@ module Travis
       end
 
       def self.amqp_ssl?
-        match = /^amqps:\/\//.match(ENV['RABBITMQ_URL'])
-        match && match.size > 0
+        !!(ENV['RABBITMQ_URL'] =~ /^amqps:\/\//)
       end
 
       define  amqp:          { username: 'guest', password: 'guest', host: 'localhost', prefetch: 1, ssl: amqp_ssl? },


### PR DESCRIPTION
This is an Enterprise patch for the issue we've been seeing where if given an `amqps://` URI `travis-logs` can't make a connection . It errors with:

```
[2016-08-09T10:12:26+0000][travis-logs:logs] com/rabbitmq/utility/BlockingCell.java:77:in `get': java.util.concurrent.TimeoutException
[2016-08-09T10:12:26+0000][travis-logs:logs]     from com/rabbitmq/utility/BlockingCell.java:111:in `uninterruptibleGet'
[2016-08-09T10:12:26+0000][travis-logs:logs]     from com/rabbitmq/utility/BlockingValueOrException.java:37:in `uninterruptibleGetValue'
[2016-08-09T10:12:26+0000][travis-logs:logs]     from com/rabbitmq/client/impl/AMQChannel.java:367:in `getReply'
[2016-08-09T10:12:26+0000][travis-logs:logs]     from com/rabbitmq/client/impl/AMQConnection.java:293:in `start'
[2016-08-09T10:12:26+0000][travis-logs:logs]     from com/rabbitmq/client/ConnectionFactory.java:647:in `newConnection'
[2016-08-09T10:12:26+0000][travis-logs:logs]     from com/rabbitmq/client/ConnectionFactory.java:694:in `newConnection'
[2016-08-09T10:12:26+0000][travis-logs:logs]     from java/lang/reflect/Method.java:606:in `invoke'
[2016-08-09T10:12:26+0000][travis-logs:logs]     from /usr/local/travis-logs/vendor/bundle/jruby/1.9/gems/march_hare-2.16.0-java/lib/march_hare/session.rb:503:in `new_connection_impl'
[2016-08-09T10:12:26+0000][travis-logs:logs]     from org/jruby/RubyProc.java:271:in `call'
[2016-08-09T10:12:26+0000][travis-logs:logs]     from /usr/local/travis-logs/vendor/bundle/jruby/1.9/gems/march_hare-2.16.0-java/lib/march_hare/session.rb:467:in `converting_rjc_exceptions_to_ruby'
[2016-08-09T10:12:26+0000][travis-logs:logs]     from /usr/local/travis-logs/vendor/bundle/jruby/1.9/gems/march_hare-2.16.0-java/lib/march_hare/session.rb:500:in `new_connection_impl'
[2016-08-09T10:12:26+0000][travis-logs:logs]     from /usr/local/travis-logs/vendor/bundle/jruby/1.9/gems/march_hare-2.16.0-java/lib/march_hare/session.rb:136:in `initialize'
[2016-08-09T10:12:26+0000][travis-logs:logs]     from /usr/local/travis-logs/vendor/bundle/jruby/1.9/gems/march_hare-2.16.0-java/lib/march_hare/session.rb:109:in `connect'
[2016-08-09T10:12:26+0000][travis-logs:logs]     from /usr/local/travis-logs/vendor/bundle/jruby/1.9/gems/march_hare-2.16.0-java/lib/march_hare.rb:20:in `connect'
[2016-08-09T10:12:26+0000][travis-logs:logs]     from /usr/local/travis-logs/vendor/bundle/jruby/1.9/bundler/gems/travis-amqp-3966b3651adf/lib/travis/amqp/march_hare.rb:23:in `connection'
[2016-08-09T10:12:26+0000][travis-logs:logs]     from /usr/local/travis-logs/lib/travis/logs/receive.rb:41:in `declare_exchanges'
[2016-08-09T10:12:26+0000][travis-logs:logs]     from /usr/local/travis-logs/lib/travis/logs/receive.rb:25:in `setup'
[2016-08-09T10:12:26+0000][travis-logs:logs]     from ./bin/receive_logs:8:in `(root)'
[2016-08-09T10:12:26+0000][travis-logs:logs]     from $_dot_/bin/./bin/receive_logs:8:in `(root)'
```

Turns out that `march_hare` (the Rabbit library we use in `travis-logs`) also wants either `tls: true` or `ssl: true` passed to it when using TLS/SSL. This PR attempts to solve this issue by looking at the protocol passed. 

A more thorough fix (for future versions and master) would likely involve a fix in `travis-config` so that it passes it along, or provides some nicer interfaces for finding out what protocol was used. 