### PR TITLE
Up default sidekiq pool size to 22

### DIFF
--- a/lib/travis/logs/config.rb
+++ b/lib/travis/logs/config.rb
@@ -8,7 +8,7 @@ module Travis
              logs_database: { adapter: 'postgresql', database: "travis_logs_#{Travis.env}", encoding: 'unicode', min_messages: 'warning' },
              s3:            { hostname: 'archive.travis-ci.org', access_key_id: '', secret_access_key: '', acl: :public_read },
              pusher:        { app_id: 'app-id', key: 'key', secret: 'secret', secure: false },
-             sidekiq:       { namespace: 'sidekiq', pool_size: 7 },
+             sidekiq:       { namespace: 'sidekiq', pool_size: 22 },
              logs:          { aggregate_async: false, archive: true, purge: false, threads: 10, per_aggregate_limit: 500, intervals: { vacuum: 10, regular: 180, force: 3 * 60 * 60, purge: 6 } },
              redis:         { url: 'redis://localhost:6379' },
              metrics:       { reporter: 'librato' },


### PR DESCRIPTION
Looks like sidekiq lied and actually wanted a pool size of 22, not 7.

> Setting up Sidekiq (pool size: 7) and Redis (connecting to host node-a18aa0b169c4aedfb.openredis.com)
> Your Redis connection pool is too small for Sidekiq to work, your pool has 7 connections but really needs to have at least 22