### PR TITLE
Add redis-namespace dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'rack-ssl'
 gem 'rack-test', group: :test
 gem 'rails_12factor'
 gem 'rake'
+gem 'redis-namespace'
 gem 'rspec', group: :test
 gem 'rubocop', require: false
 gem 'sentry-raven', github: 'getsentry/raven-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,8 @@ GEM
     rainbow (2.0.0)
     rake (10.5.0)
     redis (3.2.2)
+    redis-namespace (1.5.2)
+      redis (~> 3.0, >= 3.0.4)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
@@ -172,6 +174,7 @@ DEPENDENCIES
   rack-test
   rails_12factor
   rake
+  redis-namespace
   rspec
   rubocop
   sentry-raven!
@@ -184,4 +187,4 @@ DEPENDENCIES
   travis-support!
 
 BUNDLED WITH
-   1.11.2
+   1.13.1


### PR DESCRIPTION
so that the sidekiq redis connection client builder does not silently explode.

Sadly, this `Sidekiq.logger.error` message doesn't make it to log output in time
to be helpful :crying_cat_face: (on JRuby 9.1.5.0, at least)

https://github.com/mperham/sidekiq/blob/0f285f05e4c0e7969a0b8ccb8e736608dcebfa6a/lib/sidekiq/redis_connection.rb#L47-L48