### PR TITLE
Fix API endpoint for PUTing logs

### DIFF
--- a/lib/travis/logs/app.rb
+++ b/lib/travis/logs/app.rb
@@ -63,9 +63,11 @@ module Travis
         halt 500, 'authentication token is not set' if ENV['AUTH_TOKEN'].to_s.strip.empty?
         halt 403 if request.env['HTTP_AUTHORIZATION'] != "token #{ENV['AUTH_TOKEN']}"
 
+        p params
         job_id = Integer(params[:job_id])
 
         log = database.log_for_job_id(job_id) || database.create_log(job_id)
+        p log
 
         request.body.rewind
         database.set_log_content(log[:id], request.body.read)

--- a/lib/travis/logs/app.rb
+++ b/lib/travis/logs/app.rb
@@ -63,14 +63,12 @@ module Travis
         halt 500, 'authentication token is not set' if ENV['AUTH_TOKEN'].to_s.strip.empty?
         halt 403 if request.env['HTTP_AUTHORIZATION'] != "token #{ENV['AUTH_TOKEN']}"
 
-        p params
         job_id = Integer(params[:job_id])
 
-        log = database.log_for_job_id(job_id) || database.create_log(job_id)
-        p log
+        log_id = database.log_for_job_id(job_id) || database.create_log(job_id)
 
         request.body.rewind
-        database.set_log_content(log[:id], request.body.read)
+        database.set_log_content(log_id, request.body.read)
 
         status 204
       end

--- a/spec/integration/app_spec.rb
+++ b/spec/integration/app_spec.rb
@@ -86,7 +86,7 @@ module Travis::Logs
 
         allow(database).to receive(:set_log_content)
         allow(database).to receive(:log_for_job_id).with(anything).and_return(nil)
-        allow(database).to receive(:log_for_job_id).with(@job_id).and_return(id: @log_id, job_id: @job_id, content: '')
+        allow(database).to receive(:log_for_job_id).with(@job_id).and_return(@log_id)
       end
 
       after do


### PR DESCRIPTION
It seems `database.log_for_job_id` returns a single value which I am guessing is the `log_id`.