### PR TITLE
Allow creating an empty log via http put to logs/:id

### DIFF
--- a/lib/travis/logs/app.rb
+++ b/lib/travis/logs/app.rb
@@ -68,7 +68,9 @@ module Travis
         log_id = database.log_for_job_id(job_id) || database.create_log(job_id)
 
         request.body.rewind
-        database.set_log_content(log_id, request.body.read)
+        content = request.body.read
+        content = nil if content.empty?
+        database.set_log_content(log_id, content)
 
         status 204
       end

--- a/lib/travis/logs/helpers/database.rb
+++ b/lib/travis/logs/helpers/database.rb
@@ -118,7 +118,8 @@ module Travis
 
         def set_log_content(log_id, content)
           delete_log_parts(log_id)
-          @db[:logs].where(id: log_id).update(content: content, aggregated_at: Time.now.utc, archived_at: nil, archive_verified: nil, updated_at: Time.now.utc)
+          aggregated_at = Time.now.utc unless content.nil?
+          @db[:logs].where(id: log_id).update(content: content, aggregated_at: aggregated_at, archived_at: nil, archive_verified: nil, updated_at: Time.now.utc)
         end
 
         AGGREGATEABLE_SELECT_SQL = <<-SQL.split.join(' ')

--- a/spec/integration/app_spec.rb
+++ b/spec/integration/app_spec.rb
@@ -114,6 +114,11 @@ module Travis::Logs
           expect(database).to receive(:set_log_content).with(@log_id, 'hello, world')
           put "/logs/#{@job_id}", 'hello, world'
         end
+
+        it 'does not set log content if the given body was empty' do
+          expect(database).to receive(:set_log_content).with(@log_id, nil)
+          put "/logs/#{@job_id}", ''
+        end
       end
 
       it "returns 500 if the auth token isn't set" do


### PR DESCRIPTION
I'd like to use this endpoint in both Gatekeeper (now) and Hub (later).

Gatekeeper does two things at the moment:

* It creates an empty `log` record when a `job` is created.
* It writes a message to the log when a build is errored early (e.g. `.travis.yml` could not be parsed)

In order to create an empty log it currently uses a connection to the logs database. In order to write to the log it currently sends a part via RabbitMQ.

It seems the HTTP endpoint currently works in the latter scenario (untested so far). It would create the log record, store the content, and set it to `aggregated`.

However, in the first scenario (creating a new, empty log record) it does not work: Parts coming in later would not be aggregated into the log because it's already considered aggregated. I guess? At least I've seen pretty funky behaviour with missing log content when testing this on staging.

This change makes it so that if the given request body is empty it would not set `content` and `aggregated_at` values to the record.

I've also considered adding a `POST` endpoint instead, but I wasn't sure what the thinking is `PUT` should mean in this case (as it also already creates lazily).