### PR TITLE
database: change log_for_job_id to log_id_for_job_id

### DIFF
--- a/lib/travis/logs/app.rb
+++ b/lib/travis/logs/app.rb
@@ -65,7 +65,7 @@ module Travis
 
         job_id = Integer(params[:job_id])
 
-        log_id = database.log_for_job_id(job_id) || database.create_log(job_id)
+        log_id = database.log_id_for_job_id(job_id) || database.create_log(job_id)
 
         request.body.rewind
         content = request.body.read

--- a/lib/travis/logs/helpers/database.rb
+++ b/lib/travis/logs/helpers/database.rb
@@ -78,8 +78,13 @@ module Travis
           @db.call(:find_log, log_id: log_id).first
         end
 
-        def log_for_job_id(job_id)
-          @db.call(:find_log_id, job_id: job_id).first
+        def log_id_for_job_id(job_id)
+          log = @db.call(:find_log_id, job_id: job_id)
+          if log
+            log[:id]
+          else
+            nil
+          end
         end
 
         def log_content_length_for_id(log_id)
@@ -160,7 +165,7 @@ module Travis
 
         def prepare_statements
           @db[:logs].where(id: :$log_id).prepare(:select, :find_log)
-          @db[:logs].select(:id).where(job_id: :$job_id).prepare(:select, :find_log_id)
+          @db[:logs].select(:id).where(job_id: :$job_id).prepare(:first, :find_log_id)
           @db[:logs].prepare(:insert, :create_log,             job_id: :$job_id,
                                                                created_at: :$created_at,
                                                                updated_at: :$updated_at)

--- a/lib/travis/logs/services/process_log_part.rb
+++ b/lib/travis/logs/services/process_log_part.rb
@@ -84,8 +84,7 @@ module Travis
         alias_method :find_or_create_log, :log_id
 
         def find_log_id
-          log = database.log_for_job_id(payload['id'])
-          log ? log[:id] : nil
+          database.log_id_for_job_id(payload['id'])
         end
 
         def create_log

--- a/spec/integration/app_spec.rb
+++ b/spec/integration/app_spec.rb
@@ -85,8 +85,8 @@ module Travis::Logs
         @auth_token = ENV['AUTH_TOKEN'] = 'very-secret'
 
         allow(database).to receive(:set_log_content)
-        allow(database).to receive(:log_for_job_id).with(anything).and_return(nil)
-        allow(database).to receive(:log_for_job_id).with(@job_id).and_return(@log_id)
+        allow(database).to receive(:log_id_for_job_id).with(anything).and_return(nil)
+        allow(database).to receive(:log_id_for_job_id).with(@job_id).and_return(@log_id)
       end
 
       after do

--- a/spec/integration/database_spec.rb
+++ b/spec/integration/database_spec.rb
@@ -35,7 +35,7 @@ module Travis::Logs::Helpers
       end
     end
 
-    describe '#log_for_job_id' do
+    describe '#log_id_for_job_id' do
       context 'when the log exists' do
         let(:log) { { content: 'hello, world', job_id: 2 } }
 
@@ -43,14 +43,14 @@ module Travis::Logs::Helpers
           @log_id = sequel[:logs].insert(log)
         end
 
-        it 'returns the id of the log in a Hash' do
-          expect(database.log_for_job_id(2)).to eq(id: @log_id)
+        it 'returns the id of the log' do
+          expect(database.log_id_for_job_id(2)).to eq(@log_id)
         end
       end
 
       context 'when the log does not exist' do
         it 'returns nil' do
-          expect(database.log_for_job_id(1)).to be_nil
+          expect(database.log_id_for_job_id(1)).to be_nil
         end
       end
     end

--- a/spec/unit/travis/logs/services/process_log_part_spec.rb
+++ b/spec/unit/travis/logs/services/process_log_part_spec.rb
@@ -22,8 +22,8 @@ class FakeDatabase
     log_part_id
   end
 
-  def log_for_job_id(job_id)
-    @logs.find { |log| log[:job_id] == job_id }
+  def log_id_for_job_id(job_id)
+    @logs.select { |log| log[:job_id] == job_id }.map { |log| log[:id] }.first
   end
 end
 
@@ -47,7 +47,7 @@ module Travis::Logs::Services
       it 'creates a log' do
         service.run
 
-        expect(database.log_for_job_id(2)).not_to be_nil
+        expect(database.log_id_for_job_id(2)).not_to be_nil
       end
 
       it 'marks the log.create metric' do


### PR DESCRIPTION
This method only returned the ID, but in a Hash instead of as an integer. This changes it to return the integer directly and changes the method name to reflect that only the ID is included.

This fixes the same as #57, just in a different way (I had pushed the code last night, just forgot to open the PR).