### PR TITLE
Speed up test suite significantly

### DIFF
--- a/lib/travis/logs/services/archive_log.rb
+++ b/lib/travis/logs/services/archive_log.rb
@@ -149,7 +149,7 @@ module Travis
           yield
         rescue => e
           count ||= 0
-          if times > (count += 1) && RACK_ENV != 'test'
+          if times > (count += 1) && ENV['RACK_ENV'] != 'test'
             Travis.logger.debug(
               "action=archive retrying=#{header} " \
               "error=#{JSON.dump(e.backtrace)} type=#{e.class.name}"

--- a/lib/travis/logs/services/archive_log.rb
+++ b/lib/travis/logs/services/archive_log.rb
@@ -149,7 +149,7 @@ module Travis
           yield
         rescue => e
           count ||= 0
-          if times > (count += 1)
+          if times > (count += 1) && RACK_ENV != 'test'
             Travis.logger.debug(
               "action=archive retrying=#{header} " \
               "error=#{JSON.dump(e.backtrace)} type=#{e.class.name}"


### PR DESCRIPTION
The retrying code within ArchiveLog was executing within our test
environment, which was slowing things down unnecessarily.

The backoff is clever in that it simply adds a second for each loop
(defaulting to 5 times), but it adds (1 + 2 + 3 + 4) seconds to the test
suite.

I'm not sure if this is our preferred approach (maybe stubbing a
constant in our test would be nicer), but it's effective.