### PR TITLE
Add JSON serialisers to fix emoji rendering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'connection_pool'
 gem 'excon'
 gem 'faraday'
 gem 'jdbc-postgres', platform: :jruby
+gem 'jrjackson', platform: :jruby
 gem 'jruby-openssl', platform: :jruby
 gem 'json'
 gem 'jwt'

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'jwt'
 gem 'march_hare', '~> 2', platform: :jruby
 gem 'metriks'
 gem 'metriks-librato_metrics'
+gem 'oj', platform: :mri
 gem 'pg', platform: :mri
 gem 'pry'
 gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
       metriks (>= 0.9.9.6)
     multi_json (1.12.1)
     multipart-post (2.0.0)
+    oj (2.18.0)
     parser (2.3.3.1)
       ast (~> 2.2)
     pg (0.19.0)
@@ -181,6 +182,7 @@ DEPENDENCIES
   march_hare (~> 2)
   metriks
   metriks-librato_metrics
+  oj
   pg
   pry
   puma

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,7 @@ GEM
     i18n (0.7.0)
     jdbc-postgres (9.4.1206)
     jmespath (1.3.1)
+    jrjackson (0.4.2-java)
     jruby-openssl (0.9.19-java)
     json (2.0.2)
     json (2.0.2-java)
@@ -173,6 +174,7 @@ DEPENDENCIES
   excon
   faraday
   jdbc-postgres
+  jrjackson
   jruby-openssl
   json
   jwt
@@ -201,4 +203,4 @@ DEPENDENCIES
   travis-support!
 
 BUNDLED WITH
-   1.13.6
+   1.13.7

--- a/lib/travis/logs.rb
+++ b/lib/travis/logs.rb
@@ -1,5 +1,9 @@
 require 'travis/logs/config'
 
+if RUBY_PLATFORM =~ /^java/
+  require 'jrjackson'
+end
+
 module Travis
   def self.config
     Logs.config

--- a/lib/travis/logs.rb
+++ b/lib/travis/logs.rb
@@ -2,6 +2,8 @@ require 'travis/logs/config'
 
 if RUBY_PLATFORM =~ /^java/
   require 'jrjackson'
+else
+  require 'oj'
 end
 
 module Travis

--- a/lib/travis/logs/helpers/pusher.rb
+++ b/lib/travis/logs/helpers/pusher.rb
@@ -1,4 +1,5 @@
 require 'pusher'
+require 'multi_json'
 
 module Travis
   module Logs
@@ -33,12 +34,12 @@ module Travis
         end
 
         def pusher_payload(payload)
-          {
+          MultiJson.dump({
             'id' => payload['id'],
             '_log' => payload['chars'],
             'number' => payload['number'],
             'final' => payload['final']
-          }
+          })
         end
 
         def default_client

--- a/spec/unit/travis/logs/helpers/pusher_spec.rb
+++ b/spec/unit/travis/logs/helpers/pusher_spec.rb
@@ -1,0 +1,31 @@
+require 'travis/logs'
+require 'travis/logs/helpers/pusher'
+
+module Travis::Logs::Helpers
+  describe Pusher do
+    let(:pusher_client) { double('pusher-client') }
+    let(:pusher_channel) { double('pusher-channel') }
+    let(:pusher_helper) { described_class.new(pusher_client) }
+
+    let(:payload) {
+      {
+        'id' => '1919',
+        'chars' => 'strike! ✊',
+        'number' => '204',
+        'final' => false
+      }
+    }
+
+    before(:each) do
+      allow(pusher_client).to receive(:[]) { pusher_channel }
+      allow(pusher_channel).to receive(:trigger)
+    end
+
+    it 'pushing a payload triggers a job:log message' do
+      pusher_helper.push(payload)
+
+      expect(pusher_client).to have_received(:[]).with('job-1919')
+      expect(pusher_channel).to have_received(:trigger).with('job:log', '{"id":"1919","_log":"strike! ✊","number":"204","final":false}')
+    end
+  end
+end


### PR DESCRIPTION
Pusher is encoding the JSON itself and mangling emoji in
the process. We can instead pass it an already-encoded string
and have more control over that process. JrJackson encodes
the emoji properly.