### PR TITLE
Port SSL checking changes from `enterprise-2.0` branch

### DIFF
--- a/lib/travis/logs/config.rb
+++ b/lib/travis/logs/config.rb
@@ -13,7 +13,7 @@ module Travis
       end
       
       define amqp:          { username: 'guest', password: 'guest', host: 'localhost', prefetch: 1 },
-             logs_database: { adapter: 'postgresql', database: "travis_logs_#{env}", ssl: ssl?, encoding: 'unicode', min_messages: 'warning' },
+             logs_database: { adapter: 'postgresql', database: "travis_logs_#{Travis.env}", ssl: ssl?, encoding: 'unicode', min_messages: 'warning' },
              s3:            { hostname: 'archive.travis-ci.org', access_key_id: '', secret_access_key: '', acl: :public_read },
              pusher:        { app_id: 'app-id', key: 'key', secret: 'secret', secure: false },
              sidekiq:       { namespace: 'sidekiq', pool_size: 22 },
@@ -28,7 +28,7 @@ module Travis
 
       def env
         Travis.env
-      end
+      end 
     end
   end
 end

--- a/lib/travis/logs/config.rb
+++ b/lib/travis/logs/config.rb
@@ -23,7 +23,11 @@ module Travis
       end
 
       def ssl?
-        not %w(1 yes on).include?(ENV['PG_DISABLE_SSL'].to_s.downcase)
+        env == 'production' and not disable_ssl?
+      end
+
+      def disable_ssl?
+        %w(1 yes on).include?(ENV['PG_DISABLE_SSL'].to_s.downcase)
       end
     end
   end

--- a/lib/travis/logs/config.rb
+++ b/lib/travis/logs/config.rb
@@ -5,7 +5,7 @@ module Travis
   module Logs
     class Config < Travis::Config
       define amqp:          { username: 'guest', password: 'guest', host: 'localhost', prefetch: 1 },
-             logs_database: { adapter: 'postgresql', database: "travis_logs_#{Travis.env}", encoding: 'unicode', min_messages: 'warning' },
+             logs_database: { adapter: 'postgresql', database: "travis_logs_#{env}", ssl: ssl?, encoding: 'unicode', min_messages: 'warning' },
              s3:            { hostname: 'archive.travis-ci.org', access_key_id: '', secret_access_key: '', acl: :public_read },
              pusher:        { app_id: 'app-id', key: 'key', secret: 'secret', secure: false },
              sidekiq:       { namespace: 'sidekiq', pool_size: 22 },
@@ -20,6 +20,10 @@ module Travis
 
       def env
         Travis.env
+      end
+
+      def ssl?
+        not %w(1 yes on).include?(ENV['PG_DISABLE_SSL'].to_s.downcase)
       end
     end
   end

--- a/lib/travis/logs/config.rb
+++ b/lib/travis/logs/config.rb
@@ -4,6 +4,14 @@ require 'travis/support'
 module Travis
   module Logs
     class Config < Travis::Config
+      def self.ssl?
+        env == 'production' and not disable_ssl?
+      end
+
+      def self.disable_ssl?
+        %w(1 yes on).include?(ENV['PG_DISABLE_SSL'].to_s.downcase)
+      end
+      
       define amqp:          { username: 'guest', password: 'guest', host: 'localhost', prefetch: 1 },
              logs_database: { adapter: 'postgresql', database: "travis_logs_#{env}", ssl: ssl?, encoding: 'unicode', min_messages: 'warning' },
              s3:            { hostname: 'archive.travis-ci.org', access_key_id: '', secret_access_key: '', acl: :public_read },
@@ -20,14 +28,6 @@ module Travis
 
       def env
         Travis.env
-      end
-
-      def ssl?
-        env == 'production' and not disable_ssl?
-      end
-
-      def disable_ssl?
-        %w(1 yes on).include?(ENV['PG_DISABLE_SSL'].to_s.downcase)
       end
     end
   end

--- a/lib/travis/logs/helpers/database.rb
+++ b/lib/travis/logs/helpers/database.rb
@@ -51,7 +51,7 @@ module Travis
             password: config[:password]
           }
 
-          unless %w(1 yes on).include?(ENV['PG_DISABLE_SSL'].to_s.downcase)
+          if config[:ssl])
             params[:ssl] = true
             params[:sslfactory] = 'org.postgresql.ssl.NonValidatingFactory'
           end

--- a/lib/travis/logs/helpers/database.rb
+++ b/lib/travis/logs/helpers/database.rb
@@ -51,7 +51,7 @@ module Travis
             password: config[:password]
           }
 
-          if config[:ssl])
+          if config[:ssl]
             params[:ssl] = true
             params[:sslfactory] = 'org.postgresql.ssl.NonValidatingFactory'
           end


### PR DESCRIPTION
This PR is bringing some of the changes done in the `te-dev` (now `enterprise-2.0`) that sets up the database adapter to not use SSL when not on Heroku (where it is required).

There'll be a host of these PRs coming in from the `enterprise-2.0` branch as I get `master` in line with those changes. 

