### PR TITLE
Bump travis-config to get the new AMPQS handling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,7 +164,7 @@ GEM
       ffi
     thor (0.19.4)
     tilt (2.0.5)
-    travis-config (1.0.12)
+    travis-config (1.0.13)
       hashr (~> 2.0.0)
     unicode-display_width (1.1.2)
 


### PR DESCRIPTION
Now that https://github.com/travis-ci/travis-config/pull/9 has merged and there's a new `travis-config` version we can use the changes there to implement https://github.com/travis-ci/travis-logs/pull/47 (which only exists in the `enterprise-2.0` branch) in a cleaner way. 

This only affects HA setups using external RabbitMQ servers via the `amqps://` protocol (such as Compose.io) on Enterprise.

