### PR TITLE
Don't order the log IDs to be aggregated

### DIFF
--- a/lib/travis/logs/helpers/database.rb
+++ b/lib/travis/logs/helpers/database.rb
@@ -138,7 +138,6 @@ module Travis
             FROM log_parts
            WHERE (created_at <= NOW() - interval '? seconds' AND final = ?)
               OR  created_at <= NOW() - interval '? seconds'
-        ORDER BY created_at ASC
            LIMIT ?
         SQL
 


### PR DESCRIPTION
There's no index on created_at, so by sorting it's causing the query to slow down significantly if there's a backlog of logs to be aggregated.

This reverts commit e80dab7df7713e8bf8cf888db97f98bd93b6f229.