### PR TITLE
[Enterprise] Backport fixes to locking and aggregation

### DIFF
--- a/lib/travis/logs/aggregate.rb
+++ b/lib/travis/logs/aggregate.rb
@@ -28,10 +28,12 @@ module Travis
 
       def aggregate_logs
         exclusive do
-          Travis::Logs::Services::AggregateLogs.run
+          begin 
+            Travis::Logs::Services::AggregateLogs.run
+          rescue Exception => e
+            Travis::Exceptions.handle(e)
+          end
         end
-      rescue Exception => e
-        Travis::Exceptions.handle(e)
       end
 
       private

--- a/lib/travis/logs/helpers/locking.rb
+++ b/lib/travis/logs/helpers/locking.rb
@@ -5,15 +5,15 @@ module Travis
     module Helpers
       module Locking
         def exclusive(key, options = nil, &block)
-          options ||= config.lock.to_h
-          options[:url] ||= config.redis.url if options[:strategy] == :redis
+          options ||= Travis.config.lock.to_h
+          options[:url] ||= Travis.config.redis.url if options[:strategy] == :redis
 
           logger.debug "Locking #{key} with: #{options[:strategy]}, ttl: #{options[:ttl]}"
           Lock.exclusive(key, options, &block)
         end
 
         def logger
-          Scheduler.logger
+          Travis.logger
         end
       end
     end


### PR DESCRIPTION
While some of the locking changes from 2.0 noticed that the reason that aggregation isn't working is because there were some typos in the code getting swallowed. That work is here: https://github.com/travis-ci/travis-logs/pull/70

This PR pulls those fixes back into the 2.0 branch so we can release it in a point release and hopefully save some db space for our customers. 
