### PR TITLE
Add required Gems for fixing Aggregation in Enterprise 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'rack-ssl'
 gem 'rack-test', group: :test
 gem 'rails_12factor'
 gem 'rake'
+gem 'redis-namespace'
 gem 'redlock'
 gem 'rspec', group: :test
 gem 'rubocop', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'rack-ssl'
 gem 'rack-test', group: :test
 gem 'rails_12factor'
 gem 'rake'
+gem 'redlock'
 gem 'rspec', group: :test
 gem 'rubocop', require: false
 gem 'sentry-raven', github: 'getsentry/raven-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,9 +19,9 @@ GIT
 
 GIT
   remote: git://github.com/travis-ci/travis-lock.git
-  revision: 8aadc4cd7a1c8d89788dfc096507ee96a71fceb6
+  revision: b418401c79e082aa53a62364f7b01a9be6f0d768
   specs:
-    travis-lock (0.1.0)
+    travis-lock (0.1.1)
 
 GIT
   remote: git://github.com/travis-ci/travis-support.git
@@ -117,6 +117,8 @@ GEM
     rainbow (2.0.0)
     rake (10.5.0)
     redis (3.2.2)
+    redlock (0.2.0)
+      redis (~> 3, >= 3.0.0)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
@@ -184,6 +186,7 @@ DEPENDENCIES
   rack-test
   rails_12factor
   rake
+  redlock
   rspec
   rubocop
   sentry-raven!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,8 @@ GEM
     rainbow (2.0.0)
     rake (10.5.0)
     redis (3.2.2)
+    redis-namespace (1.5.3)
+      redis (~> 3.0, >= 3.0.4)
     redlock (0.2.0)
       redis (~> 3, >= 3.0.0)
     rspec (2.14.1)
@@ -186,6 +188,7 @@ DEPENDENCIES
   rack-test
   rails_12factor
   rake
+  redis-namespace
   redlock
   rspec
   rubocop


### PR DESCRIPTION
This is a fix to the `enterprise-2.0` branch. The code fixes already came in via https://github.com/travis-ci/travis-logs/pull/73 but missed some of the required gems to get it to actually work. 

This changes that and finally fixes aggregation in Enterprise which should help relieve a bit of db size pressure for some of our larger customers. 