### PR TITLE
[Enterprise] Only show the aggregate info when there's something to aggregate

### DIFF
--- a/lib/travis/logs/services/aggregate_logs.rb
+++ b/lib/travis/logs/services/aggregate_logs.rb
@@ -31,7 +31,7 @@ module Travis
 
           if aggregate_async?
             Travis.logger.info 'action=aggregate async=true ' \
-                               "sample#aggregateable-logs=#{ids.length}"
+                               "sample#aggregateable-logs=#{ids.length}" unless ids.length == 0
 
             ids.each do |log_id|
               Travis::Logs::Sidekiq::Aggregate.perform_async(log_id)
@@ -41,7 +41,7 @@ module Travis
           end
 
           Travis.logger.info 'action=aggregate async=false ' \
-                             "sample#aggregateable-logs=#{ids.length}"
+                             "sample#aggregateable-logs=#{ids.length}" unless ids.length == 0
           ids.each { |log_id| aggregate_log(log_id) }
         end
 


### PR DESCRIPTION
We only grab the last 2000 lines in Enterprise when doing support bundles. Chatty logs can lead to us not being able to get information we need to troubleshoot a customer. 

Right now when you look at 2.1's logs you see: 

```log
[2017-03-31T16:51:23+0000][travis-logs:aggregate] I action=aggregate async=false sample#aggregateable-logs=0
[2017-03-31T16:51:33+0000][travis-logs:aggregate] I action=aggregate async=false sample#aggregateable-logs=0
[2017-03-31T16:51:43+0000][travis-logs:aggregate] I action=aggregate async=false sample#aggregateable-logs=0
[2017-03-31T16:51:53+0000][travis-logs:aggregate] I action=aggregate async=false sample#aggregateable-logs=0
[2017-03-31T16:52:03+0000][travis-logs:aggregate] I action=aggregate async=false sample#aggregateable-logs=0
[2017-03-31T16:52:13+0000][travis-logs:aggregate] I action=aggregate async=false sample#aggregateable-logs=0
[2017-03-31T16:52:17+0000][travis-pro-api:cron] I TID=70110172467480 Found 0 cron jobs to enqueue
[2017-03-31T16:52:23+0000][travis-logs:aggregate] I action=aggregate async=false sample#aggregateable-logs=0
[2017-03-31T16:52:33+0000][travis-logs:aggregate] I action=aggregate async=false sample#aggregateable-logs=0
[2017-03-31T16:52:43+0000][travis-logs:aggregate] I action=aggregate async=false sample#aggregateable-logs=0
[2017-03-31T16:52:53+0000][travis-logs:aggregate] I action=aggregate async=false sample#aggregateable-logs=0
[2017-03-31T16:53:04+0000][travis-logs:aggregate] I action=aggregate async=false sample#aggregateable-logs=0
[2017-03-31T16:53:14+0000][travis-logs:aggregate] I action=aggregate async=false sample#aggregateable-logs=0
[2017-03-31T16:53:17+0000][travis-pro-api:cron] I TID=70110172467480 Found 0 cron jobs to enqueue
[2017-03-31T16:53:24+0000][travis-logs:aggregate] I action=aggregate async=false sample#aggregateable-logs=1
[2017-03-31T16:53:34+0000][travis-logs:aggregate] I action=aggregate async=false sample#aggregateable-logs=0
[2017-03-31T16:53:44+0000][travis-logs:aggregate] I action=aggregate async=false sample#aggregateable-logs=0
[2017-03-31T16:53:54+0000][travis-logs:aggregate] I action=aggregate async=false sample#aggregateable-logs=0
[2017-03-31T16:54:04+0000][travis-logs:aggregate] I action=aggregate async=false sample#aggregateable-logs=1
```

Which isn't telling us much. This PR makes it so it only shows messages when there's something to talk about. 

This code has changed in `master` so we'll need to do it there as well for enterprise if we want. 