### PR TITLE
Consolidate sidekiq into two worker dyno types

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,8 +1,9 @@
-aggregate_sweeper: bundle exec je bin/travis-logs-aggregate-sweeper
 drain: bundle exec je bin/travis-logs-drain
 web: bin/travis-logs-server
 worker_high: bin/travis-logs-sidekiq -c ${TRAVIS_LOGS_WORKER_HIGH_CONCURRENCY:-5} -q aggregate,1 -q log_parts,1
 worker_low: bin/travis-logs-sidekiq -c ${TRAVIS_LOGS_WORKER_LOW_CONCURRENCY:-5} -q archive,1 -q maintenance,1 -q purge_log,1
+
+aggregate_sweeper: bundle exec je bin/travis-logs-aggregate-sweeper
 
 console: bundle exec je script/console
 config: bundle exec je bin/travis-logs-config

--- a/Procfile
+++ b/Procfile
@@ -1,10 +1,8 @@
-aggregate: bin/travis-logs-sidekiq aggregate ${TRAVIS_LOGS_AGGREGATE_CONCURRENCY:-5}
 aggregate_sweeper: bundle exec je bin/travis-logs-aggregate-sweeper
-archive: bin/travis-logs-sidekiq archive ${TRAVIS_LOGS_ARCHIVE_CONCURRENCY:-5}
 drain: bundle exec je bin/travis-logs-drain
-logs: bin/travis-logs-sidekiq log_parts ${TRAVIS_LOGS_LOG_PARTS_CONCURRENCY:-5}
-purge: bin/travis-logs-sidekiq purge_log ${TRAVIS_LOGS_PURGE_CONCURRENCY:-5}
 web: bin/travis-logs-server
+worker_high: bin/travis-logs-sidekiq -c ${TRAVIS_LOGS_WORKER_HIGH_CONCURRENCY:-5} -q aggregate,1 -q logs,1
+worker_low: bin/travis-logs-sidekiq -c ${TRAVIS_LOGS_WORKER_LOW_CONCURRENCY:-5} -q archive,1 -q maintenance,1 -q purge_log,1
 
 console: bundle exec je script/console
 config: bundle exec je bin/travis-logs-config

--- a/Procfile
+++ b/Procfile
@@ -2,6 +2,7 @@ aggregate_sweeper: bundle exec je bin/travis-logs-aggregate-sweeper
 drain: bundle exec je bin/travis-logs-drain
 web: bin/travis-logs-server
 worker_high: bin/travis-logs-sidekiq -c ${TRAVIS_LOGS_WORKER_HIGH_CONCURRENCY:-5} -q aggregate,1 -q logs,1
+logs: bin/travis-logs-sidekiq -c ${TRAIS_LOGS_LOG_PARTS_CONCURRENCY:-5} -q logs
 worker_low: bin/travis-logs-sidekiq -c ${TRAVIS_LOGS_WORKER_LOW_CONCURRENCY:-5} -q archive,1 -q maintenance,1 -q purge_log,1
 
 console: bundle exec je script/console

--- a/Procfile
+++ b/Procfile
@@ -1,8 +1,7 @@
 aggregate_sweeper: bundle exec je bin/travis-logs-aggregate-sweeper
 drain: bundle exec je bin/travis-logs-drain
 web: bin/travis-logs-server
-worker_high: bin/travis-logs-sidekiq -c ${TRAVIS_LOGS_WORKER_HIGH_CONCURRENCY:-5} -q aggregate,1 -q logs,1
-logs: bin/travis-logs-sidekiq -c ${TRAIS_LOGS_LOG_PARTS_CONCURRENCY:-5} -q logs
+worker_high: bin/travis-logs-sidekiq -c ${TRAVIS_LOGS_WORKER_HIGH_CONCURRENCY:-5} -q aggregate,1 -q log_parts,1
 worker_low: bin/travis-logs-sidekiq -c ${TRAVIS_LOGS_WORKER_LOW_CONCURRENCY:-5} -q archive,1 -q maintenance,1 -q purge_log,1
 
 console: bundle exec je script/console

--- a/bin/travis-logs-run-maintenance
+++ b/bin/travis-logs-run-maintenance
@@ -5,14 +5,14 @@ libdir = File.expand_path('../../lib', __FILE__)
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 
 require 'travis/logs'
-require 'travis/config'
 
 $stdout.sync = true
 $stderr.sync = true
 
-Travis::Config::Serialize::Env.new(
-  Travis::Logs.config.to_h,
-  prefix: 'travis'
-).apply.sort.each do |entry|
-  $stdout.puts entry
-end
+Travis::Logs::Sidekiq.setup
+jid = Travis::Logs::Sidekiq::PartmanMaintenance.perform_async
+Travis.logger.info(
+  'performed async',
+  jid: jid,
+  class_name: Travis::Logs::Sidekiq::PartmanMaintenance.name
+)

--- a/bin/travis-logs-sidekiq
+++ b/bin/travis-logs-sidekiq
@@ -2,28 +2,38 @@
 set -o errexit
 
 main() {
-  if [[ $# -lt 2 ]] || [[ "$*" =~ -h|--help ]]; then
-    echo "Usage: $(basename "${0}") <queue> <concurrency>"
+  if [[ "$*" =~ -h|--help ]]; then
+    echo "Usage: $(basename "${0}") <arg> [arg...]"
     exit 1
   fi
 
   local top
   top="$(cd "$(dirname "${0}")/.." && pwd)"
 
-  local queue="${1}"
-  shift
-  local concurrency="${1}"
-  shift
+  local concurrency=1
+  local concurrency_index=0
+  local i=0
+  local args=()
+
+  for arg in "${@}"; do
+    if [[ "${arg}" = -c ]]; then
+      concurrency_index="$((i + 1))"
+    fi
+    let i+=1
+    args=( "${args[@]}" "${arg}" )
+  done
+
+  if [[ "${concurrency_index}" -gt 0 ]]; then
+    concurrency="${args[${concurrency_index}]}"
+  fi
 
   TRAVIS_SIDEKIQ_POOL_SIZE="$(( ${concurrency} + 2 ))"
   export TRAVIS_SIDEKIQ_POOL_SIZE
 
   set -o xtrace
   exec bundle exec je sidekiq \
-    -q "${queue}" \
-    -c "${concurrency}" \
     -r "${top}/lib/travis/logs/sidekiq/initializer.rb" \
-    "$@"
+    "${@}"
 }
 
 main "$@"

--- a/lib/travis/logs/config.rb
+++ b/lib/travis/logs/config.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'active_support/core_ext/numeric/time'
+
 require 'travis/config'
 
 module Travis
@@ -36,6 +38,7 @@ module Travis
             regular: 3 * 60,
             sweeper: 10 * 60
           },
+          maintenance_statement_timeout_ms: 30.minutes.in_milliseconds,
           per_aggregate_limit: 500,
           purge: false
         },

--- a/lib/travis/logs/drain_queue.rb
+++ b/lib/travis/logs/drain_queue.rb
@@ -120,6 +120,7 @@ module Travis
           end
         end
 
+        return if payload.empty?
         handler_callable.call(payload)
       end
 

--- a/lib/travis/logs/drain_queue.rb
+++ b/lib/travis/logs/drain_queue.rb
@@ -120,8 +120,7 @@ module Travis
           end
         end
 
-        return if payload.empty?
-        handler_callable.call(payload)
+        handler_callable.call(payload) unless payload.empty?
       end
 
       private def receive(delivery_info, _properties, payload)

--- a/lib/travis/logs/services.rb
+++ b/lib/travis/logs/services.rb
@@ -7,6 +7,7 @@ module Travis
       autoload :ArchiveLog, 'travis/logs/services/archive_log'
       autoload :FetchLog, 'travis/logs/services/fetch_log'
       autoload :FetchLogParts, 'travis/logs/services/fetch_log_parts'
+      autoload :PartmanMaintenance, 'travis/logs/services/partman_maintenance'
       autoload :ProcessLogPart, 'travis/logs/services/process_log_part'
       autoload :PurgeLog, 'travis/logs/services/purge_log'
       autoload :UpsertLog, 'travis/logs/services/upsert_log'

--- a/lib/travis/logs/services/partman_maintenance.rb
+++ b/lib/travis/logs/services/partman_maintenance.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Travis
+  module Logs
+    module Services
+      class PartmanMaintenance
+        include Travis::Logs::MetricsMethods
+
+        METRIKS_PREFIX = 'logs.partman_maintenance'
+
+        def self.metriks_prefix
+          METRIKS_PREFIX
+        end
+
+        def self.run
+          new.run
+        end
+
+        def run
+          table_names.each do |table_name|
+            measure(table_name) do
+              Travis.logger.info(
+                'running partman.run_maintenance',
+                table: table_name
+              )
+
+              db[<<~SQL].to_a
+                SELECT partman.run_maintenance(
+                  '#{table_name}',
+                  p_debug := true
+                )
+              SQL
+            end
+          end
+        end
+
+        private def db
+          Travis::Logs.database_connection.db
+        end
+
+        private def table_names
+          %w[
+            public.log_parts
+          ]
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/logs/services/partman_maintenance.rb
+++ b/lib/travis/logs/services/partman_maintenance.rb
@@ -24,6 +24,8 @@ module Travis
                 table: table_name
               )
 
+              db.run("SET statement_timeout = #{statement_timeout_ms}")
+
               db[<<~SQL].to_a
                 SELECT partman.run_maintenance(
                   '#{table_name}',
@@ -36,6 +38,10 @@ module Travis
 
         private def db
           Travis::Logs.database_connection.db
+        end
+
+        private def statement_timeout_ms
+          Travis.config.logs.maintenance_statement_timeout_ms
         end
 
         private def table_names

--- a/lib/travis/logs/services/partman_maintenance.rb
+++ b/lib/travis/logs/services/partman_maintenance.rb
@@ -37,7 +37,7 @@ module Travis
         end
 
         private def db
-          Travis::Logs.database_connection.db
+          @db ||= Travis::Logs::Database.create_sequel
         end
 
         private def statement_timeout_ms

--- a/lib/travis/logs/sidekiq.rb
+++ b/lib/travis/logs/sidekiq.rb
@@ -9,25 +9,26 @@ module Travis
       autoload :Aggregate, 'travis/logs/sidekiq/aggregate'
       autoload :Archive, 'travis/logs/sidekiq/archive'
       autoload :LogParts, 'travis/logs/sidekiq/log_parts'
+      autoload :PartmanMaintenance, 'travis/logs/sidekiq/partman_maintenance'
       autoload :Purge, 'travis/logs/sidekiq/purge'
 
       class << self
         def setup
           Travis.logger.info(
-            'Setting up Sidekiq and Redis',
+            'setting up sidekiq and redis',
             pool_size: Travis.config.sidekiq.pool_size,
             host: URI(Travis.config.redis.url).host
           )
           ::Sidekiq.redis = Travis::Logs.redis_pool
-          ::Sidekiq.logger = (
-            Travis.logger if Travis.config.log_level == :debug
-          )
+          ::Sidekiq.logger = ::Logger.new($stdout) if debug?
+
+          %w[Aggregate Archive LogParts PartmanMaintenance Purge].each do |name|
+            Travis::Logs::Sidekiq.const_get(name)
+          end
         end
 
-        def load_workers
-          %i[Aggregate Archive LogParts Purge].each do |worker|
-            const_get(worker)
-          end
+        def debug?
+          Travis.config.log_level.to_s == 'debug'
         end
       end
     end

--- a/lib/travis/logs/sidekiq/initializer.rb
+++ b/lib/travis/logs/sidekiq/initializer.rb
@@ -17,5 +17,4 @@ if defined?(Sidekiq)
   Travis::Exceptions.setup(Travis.config, Travis.config.env, Travis.logger)
   Travis::Metrics.setup(Travis.config.metrics, Travis.logger)
   Travis::Logs::Sidekiq.setup
-  Travis::Logs::Sidekiq.load_workers
 end

--- a/lib/travis/logs/sidekiq/partman_maintenance.rb
+++ b/lib/travis/logs/sidekiq/partman_maintenance.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'sidekiq'
+require 'sidekiq/worker'
+
+require 'travis/logs'
+
+module Travis
+  module Logs
+    module Sidekiq
+      class PartmanMaintenance
+        include ::Sidekiq::Worker
+
+        sidekiq_options queue: 'maintenance', dead: false, retry: false
+
+        def perform(*)
+          Travis::Logs::Services::PartmanMaintenance.run
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
and create new worker task for running partman maintenance per Heroku
recommendation rather than running within the ephemeral scheduled job dyno.

- [x] sidekiq setup really works