### PR TITLE
Introduce maintenance window restrictions

### DIFF
--- a/lib/travis/logs.rb
+++ b/lib/travis/logs.rb
@@ -21,6 +21,7 @@ module Travis
     autoload :DrainQueue, 'travis/logs/drain_queue'
     autoload :Existence, 'travis/logs/existence'
     autoload :Lock, 'travis/logs/lock'
+    autoload :Maintenance, 'travis/logs/maintenance'
     autoload :MetricsMethods, 'travis/logs/metrics_methods'
     autoload :MetricsMiddleware, 'travis/logs/metrics_middleware'
     autoload :Pusher, 'travis/logs/pusher'
@@ -31,7 +32,7 @@ module Travis
     autoload :Sidekiq, 'travis/logs/sidekiq'
 
     class << self
-      attr_writer :config, :database_connection, :redis_pool
+      attr_writer :config, :database_connection
 
       def config
         @config ||= Travis::Logs::Config.load
@@ -54,12 +55,12 @@ module Travis
         )
       end
 
-      def redis_pool
-        @redis_pool ||= ::Sidekiq::RedisConnection.create(
-          url: config.redis.url,
-          namespace: config.sidekiq.namespace,
-          size: config.sidekiq.pool_size
-        )
+      def redis
+        @redis ||= Travis::Logs::RedisPool.new(redis_config)
+      end
+
+      def redis_config
+        (config.logs_redis || config.redis || {}).to_h
       end
 
       def version

--- a/lib/travis/logs/app.rb
+++ b/lib/travis/logs/app.rb
@@ -104,7 +104,7 @@ module Travis
         items = Array(MultiJson.load(request.body.read))
         halt 400 unless all_items_valid?(items)
 
-        database.transaction do
+        database.db.transaction do
           items.each do |item|
             removed_by = (Integer(item['removed_by']) if item['removed_by'])
             upsert_log_service.run(

--- a/lib/travis/logs/app.rb
+++ b/lib/travis/logs/app.rb
@@ -249,7 +249,7 @@ module Travis
       end
 
       private def redis_ping
-        Travis::Logs.redis_pool.with { |conn| conn.ping.to_s }
+        Travis::Logs.redis.ping.to_s
       end
 
       private def all_items_valid?(items)

--- a/lib/travis/logs/config.rb
+++ b/lib/travis/logs/config.rb
@@ -38,6 +38,8 @@ module Travis
             regular: 3 * 60,
             sweeper: 10 * 60
           },
+          maintenance_expiry_secs: 5.minutes,
+          maintenance_initial_sleep: 30.seconds,
           maintenance_statement_timeout_ms: 30.minutes.in_milliseconds,
           per_aggregate_limit: 500,
           purge: false

--- a/lib/travis/logs/config.rb
+++ b/lib/travis/logs/config.rb
@@ -38,7 +38,7 @@ module Travis
             regular: 3 * 60,
             sweeper: 10 * 60
           },
-          maintenance_expiry_secs: 5.minutes,
+          maintenance_expiry: 5.minutes,
           maintenance_initial_sleep: 30.seconds,
           maintenance_statement_timeout_ms: 30.minutes.in_milliseconds,
           per_aggregate_limit: 500,

--- a/lib/travis/logs/database.rb
+++ b/lib/travis/logs/database.rb
@@ -63,9 +63,11 @@ module Travis
       end
 
       def initialize(config: Travis.config.logs_database.to_h,
-                     cache: nil)
+                     cache: Travis::Logs.cache,
+                     maint: Travis::Logs::Maintenance.new)
         @db = self.class.create_sequel(config: config)
-        @cache = cache || Travis::Logs.cache
+        @cache = cache
+        @maint = maint
         Travis.logger.info(
           'new database connection',
           object_id: object_id,
@@ -73,8 +75,9 @@ module Travis
         )
       end
 
-      attr_reader :db, :cache
+      attr_reader :db, :cache, :maint
       private :cache
+      private :maint
 
       def connect
         db.test_connection
@@ -116,37 +119,44 @@ module Travis
       end
 
       def update_archiving_status(log_id, archiving)
+        maint.restrict!
         db[:logs].where(id: log_id).update(archiving: archiving)
       end
 
       def mark_archive_verified(log_id)
+        maint.restrict!
         db[:logs]
           .where(id: log_id)
           .update(archived_at: Time.now.utc, archive_verified: true)
       end
 
       def mark_not_archived(log_id)
+        maint.restrict!
         db[:logs]
           .where(id: log_id)
           .update(archived_at: nil, archive_verified: false)
       end
 
       def purge(log_id)
+        maint.restrict!
         db[:logs]
           .where(id: log_id)
           .update(purged_at: Time.now.utc, content: nil)
       end
 
       def create_log(job_id)
+        maint.restrict!
         now = Time.now.utc
         db[:logs].insert(job_id: job_id, created_at: now, updated_at: now)
       end
 
       def create_log_part(params)
+        maint.restrict!
         db[:log_parts].insert(params.merge(created_at: Time.now.utc))
       end
 
       def create_log_parts(entries)
+        maint.restrict!
         now = Time.now.utc
         db[:log_parts].multi_insert(
           entries.map { |e| e.merge(created_at: now) }
@@ -154,6 +164,7 @@ module Travis
       end
 
       def delete_log_parts(log_id)
+        maint.restrict!
         db[:log_parts].where(log_id: log_id).delete
       end
 
@@ -166,7 +177,8 @@ module Travis
       end
 
       def set_log_content(log_id, content, removed_by: nil)
-        transaction do
+        maint.restrict!
+        db.transaction do
           delete_log_parts(log_id)
           now = Time.now.utc
           aggregated_at = now unless content.nil?
@@ -234,6 +246,7 @@ module Travis
       SQL
 
       def aggregate(log_id)
+        maint.restrict!
         db[AGGREGATE_UPDATE_SQL, Time.now.utc, log_id, log_id].update
       end
 
@@ -242,10 +255,6 @@ module Travis
           AGGREGATE_PARTS_SELECT_SQL,
           log_id
         ].first.fetch(:array_to_string, '') || ''
-      end
-
-      def transaction(&block)
-        db.transaction(&block)
       end
     end
   end

--- a/lib/travis/logs/existence.rb
+++ b/lib/travis/logs/existence.rb
@@ -1,36 +1,27 @@
 # frozen_string_literal: true
 
-require 'redis'
+require 'active_support/core_ext/numeric/time'
 
 require 'travis/logs'
 
 module Travis
   module Logs
     class Existence
-      attr_reader :redis
+      attr_reader :redis, :expiry
+      private :redis
+      private :expiry
 
-      class << self
-        def redis
-          @redis ||= Travis::Logs::RedisPool.new(redis_config)
-        end
-
-        def redis_config
-          (Travis.config.logs_redis || Travis.config.redis || {}).to_h
-        end
-      end
-
-      def initialize
-        @redis = self.class.redis
+      def initialize(redis: Travis::Logs.redis, expiry: 6.hours)
+        @redis = redis
+        @expiry = expiry
       end
 
       def occupied!(channel_name)
-        key = self.key(channel_name)
-        redis.set(key, true)
-        redis.expire(key, 6 * 3_600)
+        redis.setex(key(channel_name), expiry, 1)
       end
 
       def occupied?(channel_name)
-        redis.get(key(channel_name))
+        !redis.get(key(channel_name)).nil?
       end
 
       def vacant?(channel_name)

--- a/lib/travis/logs/maintenance.rb
+++ b/lib/travis/logs/maintenance.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'travis/logs'
+
+module Travis
+  module Logs
+    class Maintenance
+      class UnderMaintenanceError < StandardError
+        def initialize(ttl)
+          @ttl = ttl
+        end
+
+        attr_reader :ttl
+        private :ttl
+
+        def http_status
+          503
+        end
+
+        def message
+          "under maintenance for the next #{ttl}s"
+        end
+      end
+
+      MAINTENANCE_KEY = 'travis-logs:maintenance'
+
+      def initialize(redis: Travis::Logs.redis,
+                     expiry: Travis.config.logs.maintenance_expiry_secs)
+        @redis = redis
+        @expiry = expiry
+      end
+
+      attr_reader :redis, :expiry
+      private :redis
+      private :expiry
+
+      def with_maintenance_on
+        redis.setex(MAINTENANCE_KEY, expiry, 'on')
+        yield
+      ensure
+        redis.del(MAINTENANCE_KEY)
+      end
+
+      def enabled?
+        redis.get(MAINTENANCE_KEY) == 'on'
+      end
+
+      def restrict!
+        return unless enabled?
+        raise UnderMaintenanceError, redis.ttl(MAINTENANCE_KEY)
+      end
+    end
+  end
+end

--- a/lib/travis/logs/maintenance.rb
+++ b/lib/travis/logs/maintenance.rb
@@ -25,7 +25,7 @@ module Travis
       MAINTENANCE_KEY = 'travis-logs:maintenance'
 
       def initialize(redis: Travis::Logs.redis,
-                     expiry: Travis.config.logs.maintenance_expiry_secs)
+                     expiry: Travis.config.logs.maintenance_expiry)
         @redis = redis
         @expiry = expiry
       end

--- a/lib/travis/logs/services/aggregate_logs.rb
+++ b/lib/travis/logs/services/aggregate_logs.rb
@@ -94,7 +94,7 @@ module Travis
 
         def aggregate_log(log_id)
           measure do
-            database.transaction do
+            database.db.transaction do
               aggregate(log_id)
               clean(log_id) unless skip_empty? && log_empty?(log_id)
             end
@@ -104,7 +104,7 @@ module Travis
             'aggregating',
             action: 'aggregate', log_id: log_id, result: 'successful'
           )
-        rescue => e
+        rescue StandardError => e
           Travis::Exceptions.handle(e)
         end
 

--- a/lib/travis/logs/services/partman_maintenance.rb
+++ b/lib/travis/logs/services/partman_maintenance.rb
@@ -20,6 +20,9 @@ module Travis
           @maint = maint
         end
 
+        attr_reader :maint
+        private :maint
+
         def run
           maint.with_maintenance_on { run_maintenance }
         end

--- a/lib/travis/logs/services/partman_maintenance.rb
+++ b/lib/travis/logs/services/partman_maintenance.rb
@@ -12,11 +12,21 @@ module Travis
           METRIKS_PREFIX
         end
 
-        def self.run
-          new.run
+        def self.run(maint: Travis::Logs::Maintenance.new)
+          new(maint: maint).run
+        end
+
+        def initialize(maint: Travis::Logs::Maintenance.new)
+          @maint = maint
         end
 
         def run
+          maint.with_maintenance_on { run_maintenance }
+        end
+
+        private def run_maintenance
+          sleep(initial_sleep)
+
           table_names.each do |table_name|
             measure(table_name) do
               Travis.logger.info(
@@ -38,6 +48,10 @@ module Travis
 
         private def db
           @db ||= Travis::Logs::Database.create_sequel
+        end
+
+        private def initial_sleep
+          Travis.config.logs.maintenance_initial_sleep
         end
 
         private def statement_timeout_ms

--- a/lib/travis/logs/sidekiq.rb
+++ b/lib/travis/logs/sidekiq.rb
@@ -19,7 +19,11 @@ module Travis
             pool_size: Travis.config.sidekiq.pool_size,
             host: URI(Travis.config.redis.url).host
           )
-          ::Sidekiq.redis = Travis::Logs.redis_pool
+          ::Sidekiq.redis = ::Sidekiq::RedisConnection.create(
+            url: Travis.config.redis.url,
+            namespace: Travis.config.sidekiq.namespace,
+            size: Travis.config.sidekiq.pool_size
+          )
           ::Sidekiq.logger = ::Logger.new($stdout) if debug?
 
           %w[Aggregate Archive LogParts PartmanMaintenance Purge].each do |name|

--- a/spec/integration/app_spec.rb
+++ b/spec/integration/app_spec.rb
@@ -50,8 +50,8 @@ describe Travis::Logs::App do
 
   describe 'POST /pusher/existence' do
     it 'sets proper properties on channel' do
-      expect(existence.occupied?('foo')).to be nil
-      expect(existence.occupied?('bar')).to be nil
+      expect(existence.occupied?('foo')).to be false
+      expect(existence.occupied?('bar')).to be false
 
       webhook = OpenStruct.new(valid?: true, events: [
                                  { 'name' => 'channel_occupied', 'channel' => 'foo' },
@@ -65,8 +65,8 @@ describe Travis::Logs::App do
       response = post '/pusher/existence'
       expect(response.status).to eq(204)
 
-      expect(existence.occupied?('foo')).to eq('true')
-      expect(existence.occupied?('bar')).to be nil
+      expect(existence.occupied?('foo')).to be true
+      expect(existence.occupied?('bar')).to be false
 
       webhook = OpenStruct.new(valid?: true, events: [
                                  { 'name' => 'channel_vacated', 'channel' => 'foo' },
@@ -80,8 +80,8 @@ describe Travis::Logs::App do
       response = post '/pusher/existence'
       expect(response.status).to eq(204)
 
-      expect(existence.occupied?('foo')).to be nil
-      expect(existence.occupied?('bar')).to eq('true')
+      expect(existence.occupied?('foo')).to be false
+      expect(existence.occupied?('bar')).to be true
     end
 
     it 'responds with 401 with invalid webhook' do

--- a/spec/integration/existence_spec.rb
+++ b/spec/integration/existence_spec.rb
@@ -6,23 +6,23 @@ describe Travis::Logs::Existence do
   describe '#occupied!' do
     it 'sets channel to occupied state' do
       existence.occupied!('foo')
-      expect(existence.occupied?('foo')).to eq('true')
+      expect(existence.occupied?('foo')).to be true
 
-      expect(described_class.new.occupied?('foo')).to eq('true')
+      expect(described_class.new.occupied?('foo')).to be true
     end
   end
 
   describe '#vacant!' do
     before do
       existence.occupied!('foo')
-      expect(existence.occupied?('foo')).to eq('true')
+      expect(existence.occupied?('foo')).to be true
     end
 
     it 'sets channel to vacant state' do
       existence.vacant!('foo')
-      expect(existence.occupied?('foo')).to be nil
+      expect(existence.occupied?('foo')).to be false
 
-      expect(described_class.new.occupied?('foo')).to be nil
+      expect(described_class.new.occupied?('foo')).to be false
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,13 @@ ENV['REDIS_URL'] = 'redis://localhost:6379/0'
 ENV['TRAVIS_S3_HOSTNAME'] = 'archive-test.travis-ci.org'
 ENV['TRAVIS_LOGS_DRAIN_BATCH_SIZE'] = '1'
 
+require 'travis/exceptions'
 require 'travis/logs'
 
 Travis.logger.level = Logger::FATAL
+
+Travis::Exceptions.setup(
+  Travis.config,
+  Travis.config.env,
+  Travis.logger
+)

--- a/spec/unit/travis/logs/services/aggregate_logs_spec.rb
+++ b/spec/unit/travis/logs/services/aggregate_logs_spec.rb
@@ -9,7 +9,8 @@ describe Travis::Logs::Services::AggregateLogs do
 
   before(:each) do
     allow(archiver).to receive(:perform_async)
-    allow(database).to receive(:transaction) { |&block| block.call }
+    allow(database)
+      .to receive_message_chain(:db, :transaction) { |&block| block.call }
     allow(database).to receive(:aggregatable_logs).and_return([1, 2])
     allow(database).to receive(:log_for_id) { |id| { id: id, content: 'foo' } }
     allow(database).to receive(:aggregate)

--- a/spec/unit/travis/logs/services/purge_log_spec.rb
+++ b/spec/unit/travis/logs/services/purge_log_spec.rb
@@ -6,7 +6,7 @@ describe Travis::Logs::Services::PurgeLog do
       @database = double('database', mark_archive_verified: nil, purge: nil)
       @log_id = 1
       allow(@database).to receive(:log_content_length_for_id).with(@log_id).and_return(content_length: nil)
-      allow(@database).to receive(:transaction).and_yield
+      allow(@database).to receive_message_chain(:db, :transaction).and_yield
     end
 
     context 'log is on S3' do


### PR DESCRIPTION
so that database maintenance can progress without contending for locks without
having to figure out how to do things like stopping other dynos on a schedule.

Any database read operations should continue as usual, such as reading log_parts via travis-api, although the database content will become out of date as writes are blocked during maintenance.  Additionally, the API used by pusher should continue to respond normally.