### PR TITLE
Maintenance error handling and conflict tweaks

### DIFF
--- a/lib/travis/logs.rb
+++ b/lib/travis/logs.rb
@@ -30,6 +30,7 @@ module Travis
     autoload :SentryMiddleware, 'travis/logs/sentry_middleware'
     autoload :Services, 'travis/logs/services'
     autoload :Sidekiq, 'travis/logs/sidekiq'
+    autoload :UnderMaintenanceError, 'travis/logs/under_maintenance_error'
 
     class << self
       attr_writer :config, :database_connection

--- a/lib/travis/logs/app.rb
+++ b/lib/travis/logs/app.rb
@@ -17,6 +17,7 @@ module Travis
       helpers Sinatra::Param
 
       configure(:production, :staging) do
+        disable :dump_errors
         use Rack::SSL
         use Travis::Logs::MetricsMiddleware
       end

--- a/lib/travis/logs/config.rb
+++ b/lib/travis/logs/config.rb
@@ -42,7 +42,8 @@ module Travis
           maintenance_initial_sleep: 30.seconds,
           maintenance_statement_timeout_ms: 30.minutes.in_milliseconds,
           per_aggregate_limit: 500,
-          purge: false
+          purge: false,
+          sidekiq_error_retry_pause: 3.seconds
         },
         logs_database: {
           sql_logging: false,

--- a/lib/travis/logs/maintenance.rb
+++ b/lib/travis/logs/maintenance.rb
@@ -5,23 +5,6 @@ require 'travis/logs'
 module Travis
   module Logs
     class Maintenance
-      class UnderMaintenanceError < StandardError
-        def initialize(ttl)
-          @ttl = ttl
-        end
-
-        attr_reader :ttl
-        private :ttl
-
-        def http_status
-          503
-        end
-
-        def message
-          "under maintenance for the next #{ttl}s"
-        end
-      end
-
       MAINTENANCE_KEY = 'travis-logs:maintenance'
 
       def initialize(redis: Travis::Logs.redis,
@@ -47,7 +30,7 @@ module Travis
 
       def restrict!
         return unless enabled?
-        raise UnderMaintenanceError, redis.ttl(MAINTENANCE_KEY)
+        raise Travis::Logs::UnderMaintenanceError, redis.ttl(MAINTENANCE_KEY)
       end
     end
   end

--- a/lib/travis/logs/services/partman_maintenance.rb
+++ b/lib/travis/logs/services/partman_maintenance.rb
@@ -59,6 +59,7 @@ module Travis
           SELECT pid
           FROM pg_stat_activity
           WHERE application_name ~ '^logs\..+'
+            AND query ~ '.+log_parts.+'
         SQL
         private_constant :LOGS_QUERIES_SQL
 

--- a/lib/travis/logs/services/partman_maintenance.rb
+++ b/lib/travis/logs/services/partman_maintenance.rb
@@ -56,7 +56,6 @@ module Travis
             SELECT pid
             FROM pg_stat_activity
             WHERE application_name ~ '^logs\..+'
-              AND query ~ '^(INSERT|UPDATE).+'
           ) q
         SQL
         private_constant :TERMINATE_LOGS_WRITE_QUERIES_SQL

--- a/lib/travis/logs/services/partman_maintenance.rb
+++ b/lib/travis/logs/services/partman_maintenance.rb
@@ -28,6 +28,7 @@ module Travis
         end
 
         private def run_maintenance
+          setup_connection
           sleep(initial_sleep)
           terminate_conflicting_backends!
 
@@ -38,8 +39,6 @@ module Travis
                 table: table_name
               )
 
-              db.run("SET statement_timeout = #{statement_timeout_ms}")
-
               db[<<~SQL].to_a
                 SELECT partman.run_maintenance(
                   '#{table_name}',
@@ -48,6 +47,11 @@ module Travis
               SQL
             end
           end
+        end
+
+        def setup_connection
+          db.run("SET statement_timeout = #{statement_timeout_ms}")
+          db.run("SET application_name = 'partman_maintenance'")
         end
 
         TERMINATE_LOGS_WRITE_QUERIES_SQL = <<~SQL

--- a/lib/travis/logs/services/partman_maintenance.rb
+++ b/lib/travis/logs/services/partman_maintenance.rb
@@ -28,8 +28,8 @@ module Travis
         end
 
         private def run_maintenance
-          terminate_conflicting_backends!
           sleep(initial_sleep)
+          terminate_conflicting_backends!
 
           table_names.each do |table_name|
             measure(table_name) do

--- a/lib/travis/logs/sidekiq.rb
+++ b/lib/travis/logs/sidekiq.rb
@@ -8,6 +8,7 @@ module Travis
     module Sidekiq
       autoload :Aggregate, 'travis/logs/sidekiq/aggregate'
       autoload :Archive, 'travis/logs/sidekiq/archive'
+      autoload :ErrorMiddleware, 'travis/logs/sidekiq/error_middleware'
       autoload :LogParts, 'travis/logs/sidekiq/log_parts'
       autoload :PartmanMaintenance, 'travis/logs/sidekiq/partman_maintenance'
       autoload :Purge, 'travis/logs/sidekiq/purge'
@@ -25,9 +26,10 @@ module Travis
             size: Travis.config.sidekiq.pool_size
           )
           ::Sidekiq.logger = ::Logger.new($stdout) if debug?
-
-          %w[Aggregate Archive LogParts PartmanMaintenance Purge].each do |name|
-            Travis::Logs::Sidekiq.const_get(name)
+          ::Sidekiq.configure_server do |config|
+            config.server_middleware do |chain|
+              chain.add Travis::Logs::Sidekiq::ErrorMiddleware
+            end
           end
         end
 

--- a/lib/travis/logs/sidekiq.rb
+++ b/lib/travis/logs/sidekiq.rb
@@ -28,7 +28,8 @@ module Travis
           ::Sidekiq.logger = ::Logger.new($stdout) if debug?
           ::Sidekiq.configure_server do |config|
             config.server_middleware do |chain|
-              chain.add Travis::Logs::Sidekiq::ErrorMiddleware
+              chain.add Travis::Logs::Sidekiq::ErrorMiddleware,
+                        pause_time: Travis.config.logs.sidekiq_error_retry_pause
             end
           end
         end

--- a/lib/travis/logs/sidekiq/error_middleware.rb
+++ b/lib/travis/logs/sidekiq/error_middleware.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require 'pg'
+
+require 'travis/logs'
+
 module Travis
   module Logs
     module Sidekiq

--- a/lib/travis/logs/sidekiq/error_middleware.rb
+++ b/lib/travis/logs/sidekiq/error_middleware.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Travis
+  module Logs
+    module Sidekiq
+      class ErrorMiddleware
+        def initialize(*)
+          # nah
+        end
+
+        def call(worker, _msg, queue)
+          yield
+        rescue Travis::Logs::UnderMaintenanceError => e
+          Travis.logger.warn(
+            'rescued maintenance error',
+            worker: worker,
+            queue: queue,
+            sleeping: e.ttl
+          )
+          sleep(e.ttl)
+          retry
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/logs/sidekiq/error_middleware.rb
+++ b/lib/travis/logs/sidekiq/error_middleware.rb
@@ -22,6 +22,14 @@ module Travis
           )
           sleep(pause_time)
           retry
+        rescue PG::ConnectionBad => e
+          Travis.logger.warn(
+            'rescued bad postgres connection',
+            worker: worker,
+            queue: queue
+          )
+          sleep(pause_time)
+          retry
         end
       end
     end

--- a/lib/travis/logs/sidekiq/error_middleware.rb
+++ b/lib/travis/logs/sidekiq/error_middleware.rb
@@ -4,9 +4,12 @@ module Travis
   module Logs
     module Sidekiq
       class ErrorMiddleware
-        def initialize(*)
-          # nah
+        def initialize(pause_time: 3.seconds)
+          @pause_time = pause_time
         end
+
+        attr_reader :pause_time
+        private :pause_time
 
         def call(worker, _msg, queue)
           yield
@@ -15,9 +18,9 @@ module Travis
             'rescued maintenance error',
             worker: worker,
             queue: queue,
-            sleeping: e.ttl
+            maintenance_ttl: e.ttl
           )
-          sleep(e.ttl)
+          sleep(pause_time)
           retry
         end
       end

--- a/lib/travis/logs/under_maintenance_error.rb
+++ b/lib/travis/logs/under_maintenance_error.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Travis
+  module Logs
+    class UnderMaintenanceError < StandardError
+      def initialize(ttl)
+        @ttl = ttl
+      end
+
+      attr_reader :ttl
+
+      def http_status
+        503
+      end
+
+      def message
+        "under maintenance for the next #{ttl}s"
+      end
+    end
+  end
+end

--- a/spec/unit/travis/logs/maintenance_spec.rb
+++ b/spec/unit/travis/logs/maintenance_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+describe Travis::Logs::Maintenance do
+  let(:redis) { double(Travis::Logs::RedisPool) }
+  let(:expiry) { 1.minute }
+
+  subject do
+    described_class.new(redis: redis, expiry: expiry)
+  end
+
+  before do
+    allow(redis).to receive(:setex)
+      .with(described_class::MAINTENANCE_KEY, expiry, 'on')
+    allow(redis).to receive(:del).with(described_class::MAINTENANCE_KEY)
+  end
+
+  it 'yields with maintenance on' do
+    state = { foo: 1 }
+    subject.with_maintenance_on do
+      state[:foo] = 0
+    end
+
+    expect(state[:foo]).to eq 0
+  end
+
+  it 'tells when enabled' do
+    allow(redis).to receive(:get).with(described_class::MAINTENANCE_KEY)
+      .and_return('huh')
+
+    expect(subject.enabled?).to be false
+
+    allow(redis).to receive(:get).with(described_class::MAINTENANCE_KEY)
+      .and_return('on')
+
+    expect(subject.enabled?).to be true
+  end
+
+  it 'restricts when enabled' do
+    allow(redis).to receive(:get).with(described_class::MAINTENANCE_KEY)
+      .and_return('on')
+    allow(redis).to receive(:ttl).with(described_class::MAINTENANCE_KEY)
+      .and_return(4)
+
+    expect { subject.restrict! }
+      .to raise_error(Travis::Logs::UnderMaintenanceError)
+  end
+
+  it 'does not restrict when disabled' do
+    allow(redis).to receive(:get).with(described_class::MAINTENANCE_KEY)
+      .and_return(nil)
+
+    expect { subject.restrict! }.to_not raise_error
+  end
+end

--- a/spec/unit/travis/logs/sidekiq/error_middleware_spec.rb
+++ b/spec/unit/travis/logs/sidekiq/error_middleware_spec.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 describe Travis::Logs::Sidekiq::ErrorMiddleware do
+  subject do
+    described_class.new(pause_time: 0)
+  end
+
   it 'calls the block it wraps' do
     state = { foo: 1 }
     subject.call('worky', 'flah', 'qbert') do

--- a/spec/unit/travis/logs/sidekiq/error_middleware_spec.rb
+++ b/spec/unit/travis/logs/sidekiq/error_middleware_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+describe Travis::Logs::Sidekiq::ErrorMiddleware do
+  it 'calls the block it wraps' do
+    state = { foo: 1 }
+    subject.call('worky', 'flah', 'qbert') do
+      state[:foo] = 0
+    end
+    expect(state[:foo]).to eq 0
+  end
+
+  it 'does not handle unknown errors' do
+    expect do
+      subject.call('worky', 'flah', 'booms') do
+        raise StandardError, ':boom:'
+      end
+    end.to raise_error(StandardError)
+  end
+
+  it 'retries maintenance errors' do
+    expect do
+      state = { times: 0 }
+      subject.call('worky', 'flah', 'booms') do
+        state[:times] += 1
+        raise ArgumentError, ':boom:' if state[:times] > 1
+        raise Travis::Logs::UnderMaintenanceError, 0.01
+      end
+    end.to raise_error(ArgumentError)
+  end
+end

--- a/spec/unit/travis/logs/under_maintenance_error_spec.rb
+++ b/spec/unit/travis/logs/under_maintenance_error_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+describe Travis::Logs::UnderMaintenanceError do
+  let(:ttl) { rand(4..42) }
+  subject { described_class.new(ttl) }
+
+  it 'has a ttl' do
+    expect(subject.ttl).to eq ttl
+  end
+
+  it 'has an http_status' do
+    expect(subject.http_status).to eq 503
+  end
+
+  it 'has a message' do
+    expect(subject.message).to eq("under maintenance for the next #{ttl}s")
+  end
+end


### PR DESCRIPTION
Includes:

- adding custom sidekiq middleware to sleep and retry rather than booming into the retry queue
- terminating conflicting database queries after initial maintenance sleep to (hopefully) remove possibility of deadlock
- more specs :tada: