### PR TITLE
Require sequel one more place for safety

### DIFF
--- a/lib/travis/logs/drain_consumer.rb
+++ b/lib/travis/logs/drain_consumer.rb
@@ -4,6 +4,7 @@ require 'bunny'
 require 'coder'
 require 'concurrent'
 require 'multi_json'
+require 'sequel'
 require 'thread'
 require 'timeout'
 


### PR DESCRIPTION
since we have errors in log output of:

```
uninitialized constant Travis::Logs::DrainConsumer::Sequel
```