### PR TITLE
Create a Docker image on each commit and push to Quay

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ before_install:
 - gem update bundler
 before_script:
 - bundle exec rake setup
+env:
+  BUILD_DOCKER: true
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,6 @@ before_install:
 - gem update bundler
 before_script:
 - bundle exec rake setup
-env:
-  BUILD_DOCKER: true
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,13 @@ before_install:
 - gem update bundler
 before_script:
 - bundle exec rake setup
+
+jobs:
+  include:
+    - stage: "Testing time"
+    - stage: ":ship: it to Quay.io"
+      sudo: required
+      dist: trusty
+      install: skip
+      before_script: skip
+      script: ./script/docker-build-and-push

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,10 @@ RUN bundle install --deployment
 
 COPY . /usr/src/app
 
+# Sqitch expects partman
+# RUN /usr/src/app/script/install-partman
+
 # Install sqitch so migrations work
-RUN env PERL5DIR=/usr/local BINDIR=/usr/local/bin /usr/src/app/script/install-sqitch
+RUN /usr/src/app/script/install-sqitch
 
 CMD /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,7 @@ RUN bundle install --deployment
 
 COPY . /usr/src/app
 
+# Install sqitch so migrations work
+RUN env BINDIR=/usr/local/bin /usr/src/app/script/install-sqitch
+
 CMD /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,6 @@ RUN bundle install --deployment
 COPY . /usr/src/app
 
 # Install sqitch so migrations work
-RUN env BINDIR=/usr/local/bin /usr/src/app/script/install-sqitch
+RUN apt-get install postgresql-client && env BINDIR=/usr/local/bin /usr/src/app/script/install-sqitch
 
 CMD /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:2.4.1
 
 LABEL maintainer Travis CI GmbH <support+travis-app-docker-images@travis-ci.com>
 
-RUN apt-get update && apt-get upgrade -y --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y --no-install-recommends && apt-get install -y postgresql
 
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1
@@ -17,7 +17,8 @@ RUN bundle install --deployment
 
 COPY . /usr/src/app
 
+RUN apt-cache search postgres
 # Install sqitch so migrations work
-RUN apt-get install postgresql-client && env BINDIR=/usr/local/bin /usr/src/app/script/install-sqitch
+RUN env BINDIR=/usr/local/bin /usr/src/app/script/install-sqitch
 
 CMD /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:2.4.1
 
 LABEL maintainer Travis CI GmbH <support+travis-app-docker-images@travis-ci.com>
 
-RUN apt-get update && apt-get upgrade -y --no-install-recommends && apt-get install -y postgresql
+RUN apt-get update && apt-get upgrade -y --no-install-recommends && apt-get install -y postgresql postgresql-server-dev-9.4 liblocal-lib-perl build-essential
 
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1
@@ -17,8 +17,7 @@ RUN bundle install --deployment
 
 COPY . /usr/src/app
 
-RUN apt-cache search postgres
 # Install sqitch so migrations work
-RUN env BINDIR=/usr/local/bin /usr/src/app/script/install-sqitch
+RUN env PERL5DIR=/usr/local BINDIR=/usr/local/bin /usr/src/app/script/install-sqitch
 
 CMD /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM ruby:2.4.1
+
+LABEL maintainer Travis CI GmbH <support+travis-app-docker-images@travis-ci.com>
+
+RUN apt-get update && apt-get upgrade -y --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+# throw errors if Gemfile has been modified since Gemfile.lock
+RUN bundle config --global frozen 1
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY Gemfile      /usr/src/app
+COPY Gemfile.lock /usr/src/app
+
+RUN bundle install --deployment
+
+COPY . /usr/src/app
+
+CMD /bin/bash

--- a/db/sqitch-enterprise.plan
+++ b/db/sqitch-enterprise.plan
@@ -1,6 +1,0 @@
-%syntax-version=1.0.0
-%project=travis-logs
-
-structure 2017-04-04T19:12:07Z Dan Buch <dan@travis-ci.org> # Import initial structure for logs tables
-vacuum_settings [structure] 2017-04-04T19:37:24Z Dan Buch <dan@travis-ci.org> # Set table-level autovacuum and database-level vacuum settings
-log_parts_created_at_not_null [structure] 2017-04-04T19:52:23Z Dan Buch <dan@travis-ci.org> # Modify log_parts.created_at to be NOT NULL with default for use with partman

--- a/db/sqitch-enterprise.plan
+++ b/db/sqitch-enterprise.plan
@@ -1,0 +1,6 @@
+%syntax-version=1.0.0
+%project=travis-logs
+
+structure 2017-04-04T19:12:07Z Dan Buch <dan@travis-ci.org> # Import initial structure for logs tables
+vacuum_settings [structure] 2017-04-04T19:37:24Z Dan Buch <dan@travis-ci.org> # Set table-level autovacuum and database-level vacuum settings
+log_parts_created_at_not_null [structure] 2017-04-04T19:52:23Z Dan Buch <dan@travis-ci.org> # Modify log_parts.created_at to be NOT NULL with default for use with partman

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,4 @@
+version: "2"
+services:
+  hub:
+    build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
 version: "2"
 services:
-  logs:
+  drain:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
 version: "2"
 services:
-  hub:
+  logs:
     build: .

--- a/script/docker-build-and-push
+++ b/script/docker-build-and-push
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 set -ev
-app_name="logs"
+app_name="drain"
 local_image="travislogs_$app_name" # Docker Compose removes dashes and expects the name to end with the build app name
 quay_image=quay.io/travisci/travis-logs;
 
-docker-compose build --build-arg bundle_gems__contribsys__com="$BUNDLE_GEMS__CONTRIBSYS__COM" "$app_name";
+docker-compose build "$app_name";
 docker login -u="$QUAY_ROBOT_HANDLE" -p="$QUAY_ROBOT_TOKEN" quay.io;
 docker images;
 

--- a/script/docker-build-and-push
+++ b/script/docker-build-and-push
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -ev
+app_name="logs"
+local_image="travislogs_$app_name" # Docker Compose removes dashes and expects the name to end with the build app name
+quay_image=quay.io/travisci/travis-logs;
+
+docker-compose build --build-arg bundle_gems__contribsys__com="$BUNDLE_GEMS__CONTRIBSYS__COM" "$app_name";
+docker login -u="$QUAY_ROBOT_HANDLE" -p="$QUAY_ROBOT_TOKEN" quay.io;
+docker images;
+
+docker tag $local_image $quay_image:$TRAVIS_BRANCH;
+docker push $quay_image:$TRAVIS_BRANCH;
+
+docker tag $local_image $quay_image:${TRAVIS_COMMIT:0:7};
+docker push $quay_image:${TRAVIS_COMMIT:0:7};
+
+if [ ${TRAVIS_BRANCH} = "master" ]; then
+  docker tag $local_image $quay_image:latest;
+  docker push $quay_image:$TRAVIS_BRANCH;
+fi
+
+exit 0;

--- a/script/docker-build-and-push
+++ b/script/docker-build-and-push
@@ -2,8 +2,11 @@
 
 set -ev
 
-# Only build docker containers if we pass the build docker var, it's a cron job, or in an enterprise branch
-if [ ! -z ${BUILD_DOCKER} ] || [ ${TRAVIS_EVENT_TYPE} = "cron" ] || [[ "${TRAVIS_BRANCH}" =~ ^enterprise ]]; then
+# Only build docker containers if we pass the build docker var, if it's master, if it's a cron job, or in an enterprise branch
+if [ ! -z ${BUILD_DOCKER} ] ||
+   [ ${TRAVIS_BRANCH} = master ] ||
+   [ ${TRAVIS_EVENT_TYPE} = "cron" ] ||
+   [[ "${TRAVIS_BRANCH}" =~ ^enterprise ]]; then
   app_name="drain"
   local_image="travislogs_$app_name" # Docker Compose removes dashes and expects the name to end with the build app name
   quay_image=quay.io/travisci/travis-logs;

--- a/script/docker-build-and-push
+++ b/script/docker-build-and-push
@@ -2,9 +2,8 @@
 
 set -ev
 
-# Only build docker containers if we pass the build docker var, if it's master, if it's a cron job, or in an enterprise branch
+# Only build docker containers if we pass the build docker var, if it's a cron job (nightly builds), or in an enterprise branch
 if [ ! -z ${BUILD_DOCKER} ] ||
-   [ ${TRAVIS_BRANCH} = master ] ||
    [ ${TRAVIS_EVENT_TYPE} = "cron" ] ||
    [[ "${TRAVIS_BRANCH}" =~ ^enterprise ]]; then
   app_name="drain"

--- a/script/docker-build-and-push
+++ b/script/docker-build-and-push
@@ -1,23 +1,27 @@
 #!/bin/bash
 
 set -ev
-app_name="drain"
-local_image="travislogs_$app_name" # Docker Compose removes dashes and expects the name to end with the build app name
-quay_image=quay.io/travisci/travis-logs;
 
-docker-compose build "$app_name";
-docker login -u="$QUAY_ROBOT_HANDLE" -p="$QUAY_ROBOT_TOKEN" quay.io;
-docker images;
+# Only build docker containers if we pass the build docker var, it's a cron job, or in an enterprise branch
+if [ ! -z ${BUILD_DOCKER} ] || [ ${TRAVIS_EVENT_TYPE} = "cron" ] || [[ "${TRAVIS_BRANCH}" =~ ^enterprise ]]; then
+  app_name="drain"
+  local_image="travislogs_$app_name" # Docker Compose removes dashes and expects the name to end with the build app name
+  quay_image=quay.io/travisci/travis-logs;
 
-docker tag $local_image $quay_image:$TRAVIS_BRANCH;
-docker push $quay_image:$TRAVIS_BRANCH;
+  docker-compose build "$app_name";
+  docker login -u="$QUAY_ROBOT_HANDLE" -p="$QUAY_ROBOT_TOKEN" quay.io;
+  docker images;
 
-docker tag $local_image $quay_image:${TRAVIS_COMMIT:0:7};
-docker push $quay_image:${TRAVIS_COMMIT:0:7};
-
-if [ ${TRAVIS_BRANCH} = "master" ]; then
-  docker tag $local_image $quay_image:latest;
+  docker tag $local_image $quay_image:$TRAVIS_BRANCH;
   docker push $quay_image:$TRAVIS_BRANCH;
+
+  docker tag $local_image $quay_image:${TRAVIS_COMMIT:0:7};
+  docker push $quay_image:${TRAVIS_COMMIT:0:7};
+
+  if [ ${TRAVIS_BRANCH} = "master" ]; then
+    docker tag $local_image $quay_image:latest;
+    docker push $quay_image:$TRAVIS_BRANCH;
+  fi
 fi
 
 exit 0;

--- a/script/enterprise-migrations
+++ b/script/enterprise-migrations
@@ -3,7 +3,10 @@
 PATH="~/bin:$PATH"
 eval "$(perl -I ~/perl5/lib/perl5/ '-Mlocal::lib')"
 
+# Depends on PGHOST, PGPASSWORD, PGDATABASE, etc
+createdb
+
 # Use the LOGS_DATABASE_URL we use elsewhere but make it fit the DATABASE_URI format
 # sqitch expects
-sqitch deploy db:$LOGS_DATABASE_URL
-sqitch verify db:$LOGS_DATABASE_URL
+sqitch --plan-file db/sqitch-enterprise.plan deploy db:$LOGS_DATABASE_URL
+sqitch --plan-file db/sqitch-enterprise.plan verify db:$LOGS_DATABASE_URL

--- a/script/enterprise-migrations
+++ b/script/enterprise-migrations
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+PATH="~/bin:$PATH"
+eval "$(perl -I ~/perl5/lib/perl5/ '-Mlocal::lib')"
+
+# Use the LOGS_DATABASE_URL we use elsewhere but make it fit the DATABASE_URI format
+# sqitch expects
+sqitch deploy db:$LOGS_DATABASE_URL
+sqitch verify db:$LOGS_DATABASE_URL

--- a/script/enterprise-migrations
+++ b/script/enterprise-migrations
@@ -1,12 +1,41 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -o errexit
 
-PATH="~/bin:$PATH"
-eval "$(perl -I ~/perl5/lib/perl5/ '-Mlocal::lib')"
+main() {
+  PATH="~/bin:$PATH"
+  eval "$(perl -I ~/perl5/lib/perl5/ '-Mlocal::lib')"
 
-# Depends on PGHOST, PGPASSWORD, PGDATABASE, etc
-createdb
+  [[ "${PGHOST}" ]] || {
+    echo "Missing \$PGHOST 🐘👻"
+    exit 1
+  }
 
-# Use the LOGS_DATABASE_URL we use elsewhere but make it fit the DATABASE_URI format
-# sqitch expects
-sqitch --plan-file db/sqitch-enterprise.plan deploy db:$LOGS_DATABASE_URL
-sqitch --plan-file db/sqitch-enterprise.plan verify db:$LOGS_DATABASE_URL
+  [[ "${PGDATABASE}" ]] || {
+    echo "Missing \$PGDATABASE"
+    exit 1
+  }
+
+  [[ "${LOGS_DATABASE_URL}" ]] || {
+    echo "Missing \$LOGS_DATABASE_URL"
+    exit 1
+  }
+
+  : "${ENTERPRISE_MIGRATE_TO:=log_parts_created_at_not_null}"
+
+  # Depends on PGHOST, PGPASSWORD, PGDATABASE, etc
+  createdb
+
+  # Use the LOGS_DATABASE_URL we use elsewhere but make it fit the DATABASE_URI format
+  # sqitch expects
+  sqitch deploy \
+    --to-change "${ENTERPRISE_MIGRATE_TO}" \
+    "db:${LOGS_DATABASE_URL}"
+  sqitch deploy \
+    --log-only --no-verify \
+    "db:${LOGS_DATABASE_URL}"
+  sqitch verify \
+    --to-change "${ENTERPRISE_MIGRATE_TO}" \
+    "db:${LOGS_DATABASE_URL}"
+}
+
+main "$@"

--- a/script/install-sqitch
+++ b/script/install-sqitch
@@ -7,6 +7,7 @@ set -o errexit
 : ${PERL5DIR:=${HOME}/perl5}
 
 mkdir -p "${BINDIR}"
+mkdir -p "${CACHEDIR}"
 
 if [[ ! -f "${CACHEDIR}/cpanm" ]] ; then
   curl -sL 'https://cpanmin.us/' -o "${CACHEDIR}/cpanm"


### PR DESCRIPTION
This adds a build stage which builds and pushes a private Docker image to Quay.io

You can find it here: https://quay.io/repository/travisci/travis-logs?tab=tags

All commits are built, all pushes are tagged with the commit ref, the branch name, and with latest if the branch is master.

In the Travis settings UI, a QUAY_ROBOT_HANDLE and QUAY_ROBOT_TOKEN is configured per quay repo for pushing the Docker image.

@joshk and I have been talking about this setup for all Travis apps so that Enterprise can use them.