### PR TITLE
Make standard run loop less chatty in logs

### DIFF
--- a/lib/travis/logs/drain.rb
+++ b/lib/travis/logs/drain.rb
@@ -39,7 +39,7 @@ module Travis
       def run_loop_tick
         dead = []
         consumers.each_pair do |name, consumer|
-          Travis.logger.info('checking drain consumer', name: name)
+          Travis.logger.debug('checking drain consumer', name: name)
           if consumer.dead?
             dead << name
             Travis.logger.info('dead consumer found', name: name)

--- a/lib/travis/logs/drain_consumer.rb
+++ b/lib/travis/logs/drain_consumer.rb
@@ -104,7 +104,7 @@ module Travis
       end
 
       private def flush_batch_buffer
-        Travis.logger.info(
+        Travis.logger.debug(
           'flushing batch buffer', size: batch_buffer.size
         )
         sample = {}


### PR DESCRIPTION
In Enterprise we rely on logs for debugging since we don't have tools like Sentry to see into what has gone wrong in our customers installs. Similarly we can only grab a portion of the logs (since they can be quite large). These two factors encourages us to approach logging in enterprise to be fairly quiet unless something of note is happening. 

Right now when we look at logs in the master builds we see: 

```
[2017-07-10T14:34:07+0000][travis-logs:drain] time=2017-07-10T14:34:07+00:00 level=info msg="flushing batch buffer" size=0 tid=69887727891580
[2017-07-10T14:34:07+0000][travis-logs:drain] time=2017-07-10T14:34:07+00:00 level=info msg="flushing batch buffer" size=0 tid=69887727891580
[2017-07-10T14:34:07+0000][travis-logs:drain] time=2017-07-10T14:34:07+00:00 level=info msg="flushing batch buffer" size=0 tid=69887727891580
[2017-07-10T14:34:07+0000][travis-logs:drain] time=2017-07-10T14:34:07+00:00 level=info msg="flushing batch buffer" size=0 tid=69887727891580
[2017-07-10T14:34:07+0000][travis-logs:drain] time=2017-07-10T14:34:07+00:00 level=info msg="flushing batch buffer" size=0 tid=69887727891580
[2017-07-10T14:34:07+0000][travis-logs:drain] time=2017-07-10T14:34:07+00:00 level=info msg="flushing batch buffer" size=0 tid=69887727891580
[2017-07-10T14:34:07+0000][travis-logs:drain] time=2017-07-10T14:34:07+00:00 level=info msg="flushing batch buffer" size=0 tid=69887738746220
[2017-07-10T14:34:07+0000][travis-logs:drain] time=2017-07-10T14:34:07+00:00 level=info msg="flushing batch buffer" size=0 tid=69887727891580
[2017-07-10T14:34:07+0000][travis-logs:drain] time=2017-07-10T14:34:07+00:00 level=info msg="flushing batch buffer" size=0 tid=69887727891580
[2017-07-10T14:34:07+0000][travis-logs:drain] time=2017-07-10T14:34:07+00:00 level=info msg="flushing batch buffer" size=0 tid=69887738746220
[2017-07-10T14:34:10+0000][travis-logs:drain] time=2017-07-10T14:34:10+00:00 level=info msg="flushing batch buffer" size=0 tid=69887738746220
[2017-07-10T14:34:10+0000][travis-logs:drain] time=2017-07-10T14:34:10+00:00 level=info msg="flushing batch buffer" size=0 tid=69887738746220
[2017-07-10T14:34:10+0000][travis-logs:drain] time=2017-07-10T14:34:10+00:00 level=info msg="flushing batch buffer" size=0 tid=69887727891580
[2017-07-10T14:34:10+0000][travis-logs:drain] time=2017-07-10T14:34:10+00:00 level=info msg="flushing batch buffer" size=0 tid=69887738746220
[2017-07-10T14:34:10+0000][travis-logs:drain] time=2017-07-10T14:34:10+00:00 level=info msg="flushing batch buffer" size=0 tid=69887738746220
[2017-07-10T14:34:10+0000][travis-logs:drain] time=2017-07-10T14:34:10+00:00 level=info msg="flushing batch buffer" size=0 tid=69887738746220
[2017-07-10T14:34:10+0000][travis-logs:drain] time=2017-07-10T14:34:10+00:00 level=info msg="flushing batch buffer" size=0 tid=69887738746220
[2017-07-10T14:34:10+0000][travis-logs:drain] time=2017-07-10T14:34:10+00:00 level=info msg="flushing batch buffer" size=0 tid=69887727891580
[2017-07-10T14:34:10+0000][travis-logs:drain] time=2017-07-10T14:34:10+00:00 level=info msg="flushing batch buffer" size=0 tid=69887727891580
[2017-07-10T14:34:10+0000][travis-logs:drain] time=2017-07-10T14:34:10+00:00 level=info msg="flushing batch buffer" size=0 tid=69887727891580
[2017-07-10T14:34:11+0000][travis-logs:drain] time=2017-07-10T14:34:11+00:00 level=info msg="checking drain consumer" name=1/10 tid=69887756971900
[2017-07-10T14:34:11+0000][travis-logs:drain] time=2017-07-10T14:34:11+00:00 level=info msg="checking drain consumer" name=2/10 tid=69887756971900
[2017-07-10T14:34:11+0000][travis-logs:drain] time=2017-07-10T14:34:11+00:00 level=info msg="checking drain consumer" name=3/10 tid=69887756971900
[2017-07-10T14:34:11+0000][travis-logs:drain] time=2017-07-10T14:34:11+00:00 level=info msg="checking drain consumer" name=4/10 tid=69887756971900
[2017-07-10T14:34:11+0000][travis-logs:drain] time=2017-07-10T14:34:11+00:00 level=info msg="checking drain consumer" name=5/10 tid=69887756971900
[2017-07-10T14:34:11+0000][travis-logs:drain] time=2017-07-10T14:34:11+00:00 level=info msg="checking drain consumer" name=6/10 tid=69887756971900
[2017-07-10T14:34:11+0000][travis-logs:drain] time=2017-07-10T14:34:11+00:00 level=info msg="checking drain consumer" name=7/10 tid=69887756971900
[2017-07-10T14:34:11+0000][travis-logs:drain] time=2017-07-10T14:34:11+00:00 level=info msg="checking drain consumer" name=8/10 tid=69887756971900
[2017-07-10T14:34:11+0000][travis-logs:drain] time=2017-07-10T14:34:11+00:00 level=info msg="checking drain consumer" name=9/10 tid=69887756971900
[2017-07-10T14:34:11+0000][travis-logs:drain] time=2017-07-10T14:34:11+00:00 level=info msg="checking drain consumer" name=10/10 tid=69887756971900
```

And not much else. This happens fast enough that support bundle logs we get only contain these lines. 

In this PR I try to fix this issue by moving these log lines to `DEBUG`, but in the past we've made it so they're only show up when not Enterprise (as there may be monitoring and other things set up in hosted). I'm open to either approach! 

Other PRs that address this same issue: 

https://github.com/travis-ci/travis-logs/pull/95
https://github.com/travis-ci/travis-api/pull/469

