### PR TITLE
Ensure all log content is base64-encoded prior to JSON encoding

### DIFF
--- a/lib/travis/logs/app.rb
+++ b/lib/travis/logs/app.rb
@@ -158,7 +158,7 @@ module Travis
 
         payload = {
           'id' => Integer(params[:job_id]),
-          'log' => Base64.decode64(data['content']),
+          'log' => data['content'],
           'number' => params[:log_part_id], # NOTE: `log_part_id` may be "last"
           'final' => data['final']
         }
@@ -188,7 +188,7 @@ module Travis
 
           payloads << {
             'id' => Integer(log_part['job_id']),
-            'log' => Base64.decode64(log_part['content']),
+            'log' => log_part['content'],
             'number' => log_part['number'],
             'final' => log_part['final']
           }

--- a/lib/travis/logs/drain.rb
+++ b/lib/travis/logs/drain.rb
@@ -69,11 +69,15 @@ module Travis
 
       private def handle_batch(batch)
         Travis.logger.debug('received batch payload')
-        Travis::Logs::Sidekiq::LogParts.perform_async(batch)
+        Travis::Logs::Sidekiq::LogParts.perform_async(
+          batch.map { |e| e['log'] = Base64.strict_encode64(e['log']) }
+        )
       end
 
       private def forward_pusher_payload(payload)
-        Travis::Logs::Sidekiq::PusherForwarding.perform_async(payload)
+        Travis::Logs::Sidekiq::PusherForwarding.perform_async(
+          payload.tap { |p| p['log'] = Base64.strict_encode64(p['log']) }
+        )
       end
 
       private def consumer_count

--- a/lib/travis/logs/log_parts_writer.rb
+++ b/lib/travis/logs/log_parts_writer.rb
@@ -57,7 +57,9 @@ module Travis
         entries = by_log_id.map do |log_id, entry|
           {
             log_id: log_id,
-            content: Coder.clean!(entry['log'].to_s.delete("\0")),
+            content: Coder.clean!(
+              Base64.decode64(entry['log']).to_s.delete("\0")
+            ),
             number: entry['number'],
             final: final?(entry)
           }

--- a/lib/travis/logs/pusher_forwarder.rb
+++ b/lib/travis/logs/pusher_forwarder.rb
@@ -87,7 +87,9 @@ module Travis
       private def pusher_payload(entry)
         {
           'id' => entry['id'],
-          'chars' => Coder.clean!(entry['log'].to_s.delete("\0")),
+          'chars' => Coder.clean!(
+            Base64.decode64(entry['log']).to_s.delete("\0")
+          ),
           'number' => entry['number'],
           'final' => final?(entry)
         }

--- a/spec/integration/app_spec.rb
+++ b/spec/integration/app_spec.rb
@@ -191,7 +191,7 @@ describe Travis::Logs::App do
 
       allow(Travis::Logs::Sidekiq::LogParts).to receive(:perform_async).with(
         'id' => @job_id,
-        'log' => 'fafafaf',
+        'log' => Base64.strict_encode64('fafafaf'),
         'number' => '1',
         'final' => false
       ).and_return(nil)
@@ -208,7 +208,7 @@ describe Travis::Logs::App do
         body = MultiJson.dump(
           '@type' => 'log_part',
           'final' => false,
-          'content' => Base64.encode64('fafafaf'),
+          'content' => Base64.strict_encode64('fafafaf'),
           'encoding' => 'base64'
         )
         response = put "/log-parts/#{@job_id}/1", body
@@ -251,19 +251,19 @@ describe Travis::Logs::App do
       [
         {
           'id' => 1,
-          'log' => 'fafafaf',
+          'log' => Base64.strict_encode64('fafafaf'),
           'number' => '1',
           'final' => false
         },
         {
           'id' => 2,
-          'log' => 'fafafaf',
+          'log' => Base64.strict_encode64('fafafaf'),
           'number' => '1',
           'final' => false
         },
         {
           'id' => 5,
-          'log' => 'fafafaf',
+          'log' => Base64.strict_encode64('fafafaf'),
           'number' => '1',
           'final' => false
         }
@@ -278,7 +278,7 @@ describe Travis::Logs::App do
       ].map do |j|
         j.merge(
           :@type => 'log_part',
-          content: Base64.encode64('fafafaf'),
+          content: Base64.strict_encode64('fafafaf'),
           encoding: 'base64',
           final: false,
           number: '1'

--- a/spec/unit/travis/logs/drain_spec.rb
+++ b/spec/unit/travis/logs/drain_spec.rb
@@ -41,11 +41,11 @@ describe Travis::Logs::Drain do
 
   it 'handles batches via async log parts worker' do
     expect(Travis::Logs::Sidekiq::LogParts).to receive(:perform_async)
-    subject.send(:handle_batch, 1)
+    subject.send(:handle_batch, [])
   end
 
   it 'forwards pusher payloads via async pusher forwarding worker' do
     expect(Travis::Logs::Sidekiq::PusherForwarding).to receive(:perform_async)
-    subject.send(:forward_pusher_payload, 1)
+    subject.send(:forward_pusher_payload, 'log' => 'wat')
   end
 end

--- a/spec/unit/travis/logs/log_parts_writer_spec.rb
+++ b/spec/unit/travis/logs/log_parts_writer_spec.rb
@@ -27,7 +27,16 @@ class FakeDatabase
 end
 
 describe Travis::Logs::LogPartsWriter do
-  let(:payload) { [{ 'id' => 2, 'log' => 'hello, world', 'number' => 1 }] }
+  let(:payload) do
+    [
+      {
+        'id' => 2,
+        'log' => Base64.strict_encode64('hello, world'),
+        'number' => 1
+      }
+    ]
+  end
+
   let(:database) { FakeDatabase.new }
 
   subject(:service) do


### PR DESCRIPTION
so that we can get around encoding issues that tend to happen on the way into sidekiq queues, `Encoding::UndefinedConversionError`, e.g. https://sentry.io/travis-ci/org-logs-production/issues/281656323/