### PR TITLE
allow overriding log level for drain dyno

### DIFF
--- a/bin/travis-logs-drain
+++ b/bin/travis-logs-drain
@@ -7,7 +7,7 @@ $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 require 'travis/logs'
 
 # log level override for drain dyno
-Travis.config.log_level = ENV['DRAIN_LOG_LEVEL'] if ENV['DRAIN_LOG_LEVEL']
+Travis.logger.level = ENV['DRAIN_LOG_LEVEL'] if ENV['DRAIN_LOG_LEVEL']
 
 $stdout.sync = true
 

--- a/bin/travis-logs-drain
+++ b/bin/travis-logs-drain
@@ -6,6 +6,11 @@ $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 
 require 'travis/logs'
 
+# log level override for drain dyno
+if ENV['DRAIN_LOG_LEVEL']
+  Travis.config.log_level = ENV['DRAIN_LOG_LEVEL']
+end
+
 $stdout.sync = true
 
 Travis.logger.info('running log parts drain')

--- a/bin/travis-logs-drain
+++ b/bin/travis-logs-drain
@@ -7,9 +7,7 @@ $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 require 'travis/logs'
 
 # log level override for drain dyno
-if ENV['DRAIN_LOG_LEVEL']
-  Travis.config.log_level = ENV['DRAIN_LOG_LEVEL']
-end
+Travis.config.log_level = ENV['DRAIN_LOG_LEVEL'] if ENV['DRAIN_LOG_LEVEL']
 
 $stdout.sync = true
 


### PR DESCRIPTION
this way, log verbosity can be set on a more granular level, allowing us to turn up the log level for only the drain dyno, and not producing loads of unused and unread log messages via the other dynos.

This should help reduce the log volume of travis-logs, as we continue to hunt the elusive rabbit connection bug.