### PR TITLE
Temporarily make fetch always try aggregate if content is nil

### DIFF
--- a/lib/travis/logs/services/fetch_log.rb
+++ b/lib/travis/logs/services/fetch_log.rb
@@ -44,12 +44,15 @@ module Travis
           result = database.log_for_id(id) if id
           return nil if result.nil?
 
-          content = result[:content]
+          content       = result[:content]
+          aggregated_at = result[:aggregated_at]
 
-          if aggregate_on_demand && result[:aggregated_at].nil?
+          if aggregate_on_demand && (aggregated_at.nil? || content.nil?)
             content = [
               content, database.aggregated_on_demand(result[:id])
             ].join('')
+
+            content = nil if content.strip.empty?
           end
 
           removed_by_id = result.delete(:removed_by)


### PR DESCRIPTION
We get a lot of 406 errors from travis-api V2 when trying to fetch log
and I tracked it down to be a case when the remote log returns a nil
content (the error is wrong and it should be 404, but that's another
matter). This might happen when a log in the database has a NULL
content, but aggregated_at is still for some reason set to a value.

This commit is a hack in a way that if the diagnosis is right, we should
fix it wherever the aggregated_at is wrongly set with content still
being null. But it seems like the easiest solution at the moment.