### PR TITLE
Don't aggregate logs that don't have log parts

### DIFF
--- a/lib/travis/logs/database.rb
+++ b/lib/travis/logs/database.rb
@@ -234,17 +234,25 @@ module Travis
       SQL
 
       AGGREGATE_UPDATE_SQL = <<-SQL.split.join(' ').freeze
+        WITH log_to_update AS (
+          SELECT logs.id AS id
+          FROM logs
+          INNER JOIN log_parts ON log_parts.log_id = logs.id
+          WHERE logs.id = ?
+          GROUP BY logs.id
+        )
         UPDATE logs
            SET aggregated_at = ?,
                content = (
-                 COALESCE(content, '') || (#{AGGREGATE_PARTS_SELECT_SQL})
+                 COALESCE(content, '') || COALESCE((#{AGGREGATE_PARTS_SELECT_SQL}), '')
                )
-         WHERE logs.id = ?
+         FROM log_to_update
+         WHERE logs.id = log_to_update.id
       SQL
 
       def aggregate(log_id)
         maint.restrict!
-        db[AGGREGATE_UPDATE_SQL, Time.now.utc, log_id, log_id].update
+        db[AGGREGATE_UPDATE_SQL, log_id, Time.now.utc, log_id].update
       end
 
       def aggregated_on_demand(log_id)


### PR DESCRIPTION
(update: I changed the approach, so this is not accurate, please see the first comment for the actual description. I'm leaving the old description for more context, though)

From the commit message

```
If there're no parts for a given log array_to_string will return `NULL`
and in consequence, concatenation will also return `NULL` (because as it
turns out `'' || NULL` returns `NULL`). This theoretically shouldn't
happen, because aggregate service gets only logs that contain parts, but
if a restart is performed while the aggregate service runs, it can
potentially clear log parts for a log that is already scheduled for
aggregation.
```

While this PR would once and for all fix the problem with `nil` content for logs with not null `aggregated_at`, I'm wondering if a better fix would be to not aggregate a log without parts at all (so, in essence, construct the query in a way that `UPDATE` doesn't even happen if there're no parts).