### PR TITLE
Make logs less chatty when nothing is happening in Enterprise

### DIFF
--- a/lib/travis/logs/database.rb
+++ b/lib/travis/logs/database.rb
@@ -198,7 +198,7 @@ module Travis
         query = db[:log_parts]
                 .select(:log_id)
                 .where { created_at <= (Time.now.utc - regular_interval) }
-                .and(final: true)
+                .where(final: true)
                 .or { created_at <= (Time.now.utc - force_interval) }
                 .limit(limit)
         query = query.order(order.to_sym) unless order.nil?

--- a/lib/travis/logs/drain.rb
+++ b/lib/travis/logs/drain.rb
@@ -42,12 +42,20 @@ module Travis
           Travis.logger.debug('checking drain consumer', name: name)
           if consumer.dead?
             dead << name
-            Travis.logger.info('dead consumer found', name: name)
+            if Travis.config.enterprise
+              Travis.logger.debug('dead consumer found', name: name)
+            else
+              Travis.logger.info('dead consumer found', name: name)
+            end
           end
         end
 
         dead.each do |name|
-          Travis.logger.info('creating new consumer', name: name)
+          if Travis.config.enterprise
+            Travis.logger.debug('creating new consumer', name: name)
+          else
+            Travis.logger.info('creating new consumer', name: name)
+          end
           consumers[name] = create_consumer
           consumers[name].subscribe
         end

--- a/lib/travis/logs/drain.rb
+++ b/lib/travis/logs/drain.rb
@@ -42,7 +42,7 @@ module Travis
           Travis.logger.debug('checking drain consumer', name: name)
           if consumer.dead?
             dead << name
-            Travis.logger.debug('dead consumer found', name: name)
+            Travis.logger.info('dead consumer found', name: name)
           end
         end
 

--- a/lib/travis/logs/drain.rb
+++ b/lib/travis/logs/drain.rb
@@ -9,7 +9,7 @@ module Travis
     class Drain
       def self.setup
         return if defined?(@setup)
-        Travis.logger.info('setting up drain dependencies')
+        Travis.logger.debug('setting up drain dependencies')
         Travis::Exceptions.setup(
           Travis.config, Travis.config.env, Travis.logger
         )
@@ -21,7 +21,7 @@ module Travis
       def run(once: false)
         self.class.setup
 
-        Travis.logger.info(
+        Travis.logger.debug(
           'setting up log parts drain consumers',
           count: consumer_count
         )
@@ -42,20 +42,12 @@ module Travis
           Travis.logger.debug('checking drain consumer', name: name)
           if consumer.dead?
             dead << name
-            if Travis.config.enterprise
-              Travis.logger.debug('dead consumer found', name: name)
-            else
-              Travis.logger.info('dead consumer found', name: name)
-            end
+            Travis.logger.debug('dead consumer found', name: name)
           end
         end
 
         dead.each do |name|
-          if Travis.config.enterprise
-            Travis.logger.debug('creating new consumer', name: name)
-          else
-            Travis.logger.info('creating new consumer', name: name)
-          end
+          Travis.logger.debug('creating new consumer', name: name)
           consumers[name] = create_consumer
           consumers[name].subscribe
         end

--- a/lib/travis/logs/drain_consumer.rb
+++ b/lib/travis/logs/drain_consumer.rb
@@ -36,7 +36,12 @@ module Travis
       end
 
       def subscribe
-        Travis.logger.info('subscribing', queue: jobs_queue.name)
+        if Travis.config.enterprise
+          Travis.logger.debug('subscribing', queue: jobs_queue.name)
+        else
+          Travis.logger.info('subscribing', queue: jobs_queue.name)
+        end
+
         jobs_queue.subscribe(manual_ack: true, &method(:receive))
       rescue Bunny::TCPConnectionFailedForAllHosts
         @dead = true
@@ -85,10 +90,11 @@ module Travis
       end
 
       private def shutdown(reason)
-        Travis.logger.info(
-          'shutting down drain consumer',
-          reason: reason
-        )
+        if Travis.config.enterprise
+          Travis.logger.debug('shutting down drain consumer', reason: reason)
+        else
+          Travis.logger.info('shutting down drain consumer', reason: reason)
+        end
         amqp_conn.close
       rescue StandardError => e
         Travis::Exceptions.handle(e)

--- a/lib/travis/logs/drain_consumer.rb
+++ b/lib/travis/logs/drain_consumer.rb
@@ -36,11 +36,7 @@ module Travis
       end
 
       def subscribe
-        if Travis.config.enterprise
-          Travis.logger.debug('subscribing', queue: jobs_queue.name)
-        else
-          Travis.logger.info('subscribing', queue: jobs_queue.name)
-        end
+        Travis.logger.debug('subscribing', queue: jobs_queue.name)
 
         jobs_queue.subscribe(manual_ack: true, &method(:receive))
       rescue Bunny::TCPConnectionFailedForAllHosts
@@ -90,11 +86,7 @@ module Travis
       end
 
       private def shutdown(reason)
-        if Travis.config.enterprise
-          Travis.logger.debug('shutting down drain consumer', reason: reason)
-        else
-          Travis.logger.info('shutting down drain consumer', reason: reason)
-        end
+        Travis.logger.debug('shutting down drain consumer', reason: reason)
         amqp_conn.close
       rescue StandardError => e
         Travis::Exceptions.handle(e)
@@ -174,7 +166,7 @@ module Travis
             flush_mutex.synchronize { flush_batch_buffer }
           end
         else
-          Travis.logger.info('acking empty or undecodable payload')
+          Travis.logger.debug('acking empty or undecodable payload')
           safe_ack(delivery_info.delivery_tag)
         end
       rescue => e

--- a/lib/travis/logs/services/aggregate_logs.rb
+++ b/lib/travis/logs/services/aggregate_logs.rb
@@ -42,7 +42,9 @@ module Travis
 
           ids = aggregatable_ids
           if ids.empty?
-            Travis.logger.info('no aggregatable ids') unless Travis.config.enterprise
+            if !Travis.config.enterprise
+              Travis.logger.info('no aggregatable ids')
+            end
             return
           end
 

--- a/lib/travis/logs/services/aggregate_logs.rb
+++ b/lib/travis/logs/services/aggregate_logs.rb
@@ -34,10 +34,15 @@ module Travis
         end
 
         def run
-          Travis.logger.info('fetching aggregatable ids')
+          if Travis.config.enterprise
+            Travis.logger.debug('fetching aggregatable ids')
+          else
+            Travis.logger.info('fetching aggregatable ids')
+          end
+
 
           ids = aggregatable_ids
-          if ids.empty?
+          if ids.empty? && !Travis.config.enterprise
             Travis.logger.info('no aggregatable ids')
             return
           end

--- a/lib/travis/logs/services/aggregate_logs.rb
+++ b/lib/travis/logs/services/aggregate_logs.rb
@@ -40,7 +40,6 @@ module Travis
             Travis.logger.info('fetching aggregatable ids')
           end
 
-
           ids = aggregatable_ids
           if ids.empty? && !Travis.config.enterprise
             Travis.logger.info('no aggregatable ids')

--- a/lib/travis/logs/services/aggregate_logs.rb
+++ b/lib/travis/logs/services/aggregate_logs.rb
@@ -34,17 +34,11 @@ module Travis
         end
 
         def run
-          if Travis.config.enterprise
-            Travis.logger.debug('fetching aggregatable ids')
-          else
-            Travis.logger.info('fetching aggregatable ids')
-          end
+          Travis.logger.debug('fetching aggregatable ids')
 
           ids = aggregatable_ids
           if ids.empty?
-            if !Travis.config.enterprise
-              Travis.logger.info('no aggregatable ids')
-            end
+            Travis.logger.debug('no aggregatable ids')
             return
           end
 
@@ -52,7 +46,7 @@ module Travis
             'aggregating with pool config',
             pool_config.merge(action: 'aggregate')
           )
-          Travis.logger.info(
+          Travis.logger.debug(
             'starting aggregation batch',
             size: ids.length, action: 'aggregate',
             'sample#aggregatable-logs': ids.length
@@ -63,7 +57,7 @@ module Travis
           pool.shutdown
           pool.wait_for_termination
 
-          Travis.logger.info(
+          Travis.logger.debug(
             'finished aggregation batch',
             size: ids.length, action: 'aggregate'
           )
@@ -72,7 +66,7 @@ module Travis
         def run_ranges(cursor, per_page)
           cursor ||= database.min_log_part_id
 
-          Travis.logger.info('fetching aggregatable ids', cursor: cursor)
+          Travis.logger.debug('fetching aggregatable ids', cursor: cursor)
           ids = database.aggregatable_logs_page(cursor, per_page)
 
           if ids.empty?
@@ -84,7 +78,7 @@ module Travis
             'aggregating with pool config',
             pool_config.merge(action: 'aggregate')
           )
-          Travis.logger.info(
+          Travis.logger.debug(
             'starting aggregation batch',
             action: 'aggregate', 'sample#aggregatable-logs': ids.length
           )
@@ -94,7 +88,7 @@ module Travis
           pool.shutdown
           pool.wait_for_termination
 
-          Travis.logger.info('finished aggregation batch', action: 'aggregate')
+          Travis.logger.debug('finished aggregation batch', action: 'aggregate')
           cursor + per_page
         end
 

--- a/lib/travis/logs/services/aggregate_logs.rb
+++ b/lib/travis/logs/services/aggregate_logs.rb
@@ -41,8 +41,8 @@ module Travis
           end
 
           ids = aggregatable_ids
-          if ids.empty? && !Travis.config.enterprise
-            Travis.logger.info('no aggregatable ids')
+          if ids.empty?
+            Travis.logger.info('no aggregatable ids') unless Travis.config.enterprise
             return
           end
 


### PR DESCRIPTION
1. What is the problem that this PR is trying to fix?

This is part of the effort to lower the amount of noise in the logs in Enterprise (will cross reference from that issue since it's in a private repo). The gist of it is that in Enterprise we do a lot of troubleshooting via logs. But at the moment we only grab the last 2k lines of logs and often if an error has happened and enough time has passed the logs are filled with informational logging stating that there's nothing to be done. What this effort is trying to address (and this PR as part of it) is to lower that noise level so that it mostly logs when things happen, moving the more intense detail to the debug level. 


2. What approach did you choose and why?

I chose simple `if` statements around the logging bits in question to check if we were in Enterprise or not. Much like mentioned in https://github.com/travis-ci/travis-api/pull/595 it's possible that we could move all of these to the `debug` level but I don't know the specifics of how we use these bits of logging in production so I opted to keep them as they are now. 


3. How can you test this?

I can test this by deploying it to staging and making sure the statements are still intact for hosted as well as making a new Enterprise build with this branch to make sue they _don't_ show up there. 

4. What feedback would you like?

I'm curious if there's other places where we feel this approach could be good, or perhaps if there's away we can go away from the `if` statements (without rewriting `Travis.logger` - more like moving to `debug` level for most of these statements?)