### PR TITLE
More switching logger to debug, this time for drain consumers 

### DIFF
--- a/lib/travis/logs/drain.rb
+++ b/lib/travis/logs/drain.rb
@@ -42,7 +42,7 @@ module Travis
           Travis.logger.debug('checking drain consumer', name: name)
           if consumer.dead?
             dead << name
-            Travis.logger.info('dead consumer found', name: name)
+            Travis.logger.debug('dead consumer found', name: name)
           end
         end
 


### PR DESCRIPTION
1. What is the problem that this PR is trying to fix?

We started work in #164 to make the logs a lot less chatty for Enterprise making debugging work easier. @igorwwwwwwwwwwwwwwwwwwww brought up in https://github.com/travis-ci/travis-logs/pull/164#discussion_r154023240 that dead drain consumers can be a symptom of poor rabbit connections. 

We continued to see more of these messages on a very regular basis and instead tracked it down to `drain_ack_timeout` being set to 300 seconds and on an Enterprise instance with not much activity this will mark things as dead often (https://github.com/travis-ci/travis-logs/blob/master/lib/travis/logs/drain_consumer.rb#L54). Still, I didn't want to lose that information so I checked what _did_ happen when Rabbit was having issues. Turns out there was loads of other errors letting us know, so I felt ok bumping this `debug` instead of info. 

2. What approach did you choose and why?

I bumped this to `debug` since it's not providing extra information that we need and that fits with the rest of the changes in #164. Additionally in Enterprise consider bumping `drain_ack_timeout` to something more akin to an 30 minutes-1 hour so we're spending CPU cycles every 5 minutes to restart all of them (though I suppose on a busy instance where we need those cycles this wouldn't be an issue). Going to evaluate things after this change to see how it feels. 

3. How can you test this?

Build a new Enterprise container and watch the log with no activity. 

4. What feedback would you like?

This feels pretty clean cut, but if this is a terrible idea, any level of waving and screaming "No! Don't do it!" would be appreciated. 😜 