### PR TITLE
Raise continuation timeout

### DIFF
--- a/lib/travis/logs/config.rb
+++ b/lib/travis/logs/config.rb
@@ -10,7 +10,8 @@ module Travis
       define(
         amqp: {
           automatic_recovery: true,
-          recover_from_connection_close: true
+          recover_from_connection_close: true,
+          continuation_timeout: 15000
         },
         channels_existence_check: true,
         lock: { strategy: :redis, ttl: 150 },


### PR DESCRIPTION
The default is 4000. [This comment](https://github.com/ruby-amqp/bunny/issues/378#issuecomment-182363979) suggests 15000.