### PR TITLE
remove references to the postgres read-replica (readonly database)

### DIFF
--- a/lib/travis/logs.rb
+++ b/lib/travis/logs.rb
@@ -56,12 +56,6 @@ module Travis
         @database_connection ||= Travis::Logs::Database.connect
       end
 
-      def readonly_database_connection
-        @readonly_database_connection ||= Travis::Logs::Database.connect(
-          config: config.logs_readonly_database.to_h
-        )
-      end
-
       def redis
         @redis ||= Travis::Logs::RedisPool.new(redis_config)
       end

--- a/lib/travis/logs/app.rb
+++ b/lib/travis/logs/app.rb
@@ -72,7 +72,7 @@ module Travis
         json uptime: Time.now.utc - boot_time,
              greeting: 'hello, human 👋!',
              pong: redis_ping,
-             now: readonly_database.now,
+             now: database.now,
              version: Travis::Logs.version
       end
 
@@ -274,10 +274,6 @@ module Travis
 
       private def database
         @database ||= Travis::Logs.database_connection
-      end
-
-      private def readonly_database
-        @readonly_database ||= Travis::Logs.readonly_database_connection
       end
 
       private def maint

--- a/lib/travis/logs/config.rb
+++ b/lib/travis/logs/config.rb
@@ -57,13 +57,6 @@ module Travis
             "postgres://localhost/travis_logs_#{env}"
           )
         },
-        logs_readonly_database: {
-          sql_logging: false,
-          url: ENV.fetch(
-            'LOGS_READONLY_DATABASE_URL',
-            "postgres://localhost/travis_logs_#{env}"
-          )
-        },
         memcached: {
           servers: ENV.fetch('MEMCACHIER_SERVERS', ''),
           username: ENV.fetch('MEMCACHIER_USERNAME', ''),


### PR DESCRIPTION
The read replica is currently unused. So we should be able to remove all references and then drop that database.

refs https://github.com/travis-ci/reliability/issues/14