### PR TITLE
[Enterprise Backport] Fix issue where drain leaks threads after discovering dead consumers. (#171)

### DIFF
--- a/lib/travis/logs/drain_consumer.rb
+++ b/lib/travis/logs/drain_consumer.rb
@@ -97,7 +97,6 @@ module Travis
       ensure
         @dead = true
         @batch_buffer = nil
-        sleep
       end
 
       private def build_periodic_flush_task


### PR DESCRIPTION
Backporting #171 for `enterprise-2.2` 