### PR TITLE
[Enterprise 2.2 Backport] Update bunny gem to get SNI support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,7 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    amq-protocol (2.2.0)
+    amq-protocol (2.3.0)
     ast (2.3.0)
     atomic (1.1.99)
     avl_tree (1.2.1)
@@ -70,8 +70,8 @@ GEM
       aws-sdk-core (= 2.10.15)
     aws-sigv4 (1.0.1)
     backports (3.8.0)
-    bunny (2.7.0)
-      amq-protocol (>= 2.2.0)
+    bunny (2.9.2)
+      amq-protocol (~> 2.3.0)
     coder (0.4.0)
     coderay (1.1.1)
     concurrent-ruby (1.0.5)
@@ -221,4 +221,4 @@ DEPENDENCIES
   travis-metrics!
 
 BUNDLED WITH
-   1.16.0
+   1.16.1


### PR DESCRIPTION
`master` is up to date already. But we need this in 2.2 so I'm updating it here. 

What I've said in similar PRs for hub and api and scheduler: 

> One of the known issues in Enterprise is that you cannot currently use it with Compose.io or other external RabbitMQ servers that rely on SNI instead of client certificates. This has to do with the version of the bunny gem that's currently installed. So this PR is part of the effort to bring us up to the latest version which fixes this issue (among many others).
>
>Bunny SNI PR: ruby-amqp/bunny#443
>Bunny Changelog: https://github.com/ruby-amqp/bunny/blob/master/ChangeLog.md
