### PR TITLE
pg_partman: move analyze out of maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,21 @@ The schema and migrations for travis-logs are managed with
 [sqitch](http://sqitch.org/).  All of the deploy, verify, and revert scripts may
 be found in the `./db/` directory.
 
+To install sqitch locally, you can run:
+
+```
+$ script/install-sqitch
+```
+
+To run sqitch, you can run:
+
+```
+$ script/sqitch-heroku LOGS_DATABASE_URL travis-logs-staging status
+```
+
+For more information on how to use sqitch and how to add migrations, you can
+take a look at the [sqitch tutorial](https://metacpan.org/pod/sqitchtutorial).
+
 ### Data lifecycle
 
 The process types above use PostgreSQL for various operations, with a structure

--- a/db/deploy/partman_remove_constraint.sql
+++ b/db/deploy/partman_remove_constraint.sql
@@ -1,0 +1,12 @@
+-- Deploy travis-logs:partman_remove_constraint to pg
+-- requires: partman
+
+BEGIN;
+
+  SET client_min_messages = WARNING;
+
+  UPDATE partman.part_config
+  SET constraint_cols = '{}'
+  WHERE parent_table = 'public.log_parts';
+
+COMMIT;

--- a/db/revert/partman_remove_constraint.sql
+++ b/db/revert/partman_remove_constraint.sql
@@ -1,0 +1,11 @@
+-- Revert travis-logs:partman_remove_constraint from pg
+
+BEGIN;
+
+  SET client_min_messages = WARNING;
+
+  UPDATE partman.part_config
+  SET constraint_cols = '{log_id}'
+  WHERE parent_table = 'public.log_parts';
+
+COMMIT;

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -5,3 +5,4 @@ structure 2017-04-04T19:12:07Z Dan Buch <dan@travis-ci.org> # Import initial str
 vacuum_settings [structure] 2017-04-04T19:37:24Z Dan Buch <dan@travis-ci.org> # Set table-level autovacuum and database-level vacuum settings
 log_parts_created_at_not_null [structure] 2017-04-04T19:52:23Z Dan Buch <dan@travis-ci.org> # Modify log_parts.created_at to be NOT NULL with default for use with partman
 partman [log_parts_created_at_not_null] 2017-04-04T20:24:49Z Dan Buch <dan@travis-ci.org> # Enable and configure partman for log_parts
+partman_remove_constraint 2018-04-27T11:41:39Z Igor Wiedler <igor@travis-ci.org> # Remove partman constraint exclusion on log_id column

--- a/db/verify/partman_remove_constraint.sql
+++ b/db/verify/partman_remove_constraint.sql
@@ -1,0 +1,12 @@
+-- Verify travis-logs:partman_remove_constraint on pg
+
+BEGIN;
+
+  SET client_min_messages = WARNING;
+
+  SELECT 1/count(*)
+  FROM partman.part_config
+  WHERE parent_table = 'public.log_parts'
+  AND constraint_cols = '{}';
+
+ROLLBACK;

--- a/lib/travis/logs/services/partman_maintenance.rb
+++ b/lib/travis/logs/services/partman_maintenance.rb
@@ -25,6 +25,7 @@ module Travis
 
         def run
           maint.with_maintenance_on { run_maintenance }
+          run_analyze
         end
 
         private def run_maintenance
@@ -41,8 +42,23 @@ module Travis
               db[<<~SQL].to_a
                 SELECT partman.run_maintenance(
                   '#{table_name}',
-                  p_debug := true
+                  p_debug := true,
+                  p_analyze := false
                 )
+              SQL
+            end
+          end
+        end
+        
+        private def run_analyze
+          table_names.each do |table_name|
+            measure(table_name) do
+              Travis.logger.info(
+                'running analyze',
+                table: table_name
+              )
+              db[<<~SQL].to_a
+                ANALYZE #{table_name}
               SQL
             end
           end

--- a/lib/travis/logs/services/partman_maintenance.rb
+++ b/lib/travis/logs/services/partman_maintenance.rb
@@ -34,7 +34,7 @@ module Travis
           cancel_conflicting_backends
           terminate_conflicting_backends!
           table_names.each do |table_name|
-            measure(table_name) do
+            measure("maintenance.#{table_name}") do
               Travis.logger.info(
                 'running partman.run_maintenance',
                 table: table_name
@@ -52,7 +52,7 @@ module Travis
 
         private def run_analyze
           table_names.each do |table_name|
-            measure(table_name) do
+            measure("analyze.#{table_name}") do
               Travis.logger.info(
                 'running analyze',
                 table: table_name

--- a/lib/travis/logs/services/partman_maintenance.rb
+++ b/lib/travis/logs/services/partman_maintenance.rb
@@ -49,7 +49,7 @@ module Travis
             end
           end
         end
-        
+
         private def run_analyze
           table_names.each do |table_name|
             measure(table_name) do


### PR DESCRIPTION
Please make sure you cover the following points:

1. What is the problem that this PR is trying to fix?

Our nightly `pg_partman` maintenance is taking a long time. Sometimes up to 20-30 minutes. This is impacting the availability of the logs service.

2. What approach did you choose and why?

keithf4 recommended trying to run the maintenance without analyze and then run the analyze separately.

3. How can you test this?

We can trigger a maintenance on staging and make sure nothing breaks. Then do the same in production, or let it run nightly and check the results.

(4. What feedback would you like?)

refs travis-ci/reliability#85