### PR TITLE
let exceptions bubble up during aggregation

### DIFF
--- a/lib/travis/logs/services/aggregate_logs.rb
+++ b/lib/travis/logs/services/aggregate_logs.rb
@@ -104,8 +104,6 @@ module Travis
             'aggregating',
             action: 'aggregate', log_id: log_id, result: 'successful'
           )
-        rescue StandardError => e
-          Travis::Exceptions.handle(e)
         end
 
         attr_reader :database, :pool_config


### PR DESCRIPTION
1. What is the problem that this PR is trying to fix?

Aggregating logs is timing out at times on org ([about 600 times a day](https://sentry.io/travis-ci/org-logs-production/issues/450396775/?query=is:unresolved)). Once that happens, we do not re-try the aggregation. Thus, the log parts will remain in postgres (a million per day), which also means more reads will have to go to postgres instead of s3.

Rescuing the error here effectively stops the chain. Which means we also won't perform later steps such as archiving.

It is also possible that this creates a vicious cycle where extra load on postgres causes more queries to time out, which causes less of them to get aggregated.

2. What approach did you choose and why?

If we let the error bubble up, then sidekiq will re-try the job again. Hopefully these are somewhat intermittent timeouts that will be fixed by a retry. If it is consistently taking longer than 10 seconds to aggregate, then that suggests a deeper problem.

This change also has the effect of letting other sidekiq middlewares like the metrics one report error counts correctly.

3. How can you test this?

Deploy to prod and see if the number of log parts drops. e.g.:

```
travis-logs-production::LOGS_DATABASE=> select count(*) from log_parts_p2018_04_30;

travis-logs-production::LOGS_DATABASE=> select count(distinct log_id) from log_parts_p2018_04_30;
```

Hopefully it will be significantly less than 1 million log parts, and less than 600 distinct unarchived log ids.

(4. What feedback would you like?)

refs travis-ci/reliability#85