### PR TITLE
allow forcing config.pusher.secure to true

### DIFF
--- a/lib/travis/logs/config.rb
+++ b/lib/travis/logs/config.rb
@@ -67,7 +67,7 @@ module Travis
           app_id: '',
           key: '',
           secret: '',
-          secure: false
+          secure: !!ENV['PUSHER_SECURE']
         },
         redis: { url: '' },
         s3: {

--- a/lib/travis/logs/config.rb
+++ b/lib/travis/logs/config.rb
@@ -67,7 +67,7 @@ module Travis
           app_id: '',
           key: '',
           secret: '',
-          secure: !!ENV['PUSHER_SECURE']
+          secure: !ENV['PUSHER_SECURE'].nil?
         },
         redis: { url: '' },
         s3: {


### PR DESCRIPTION
Pusher log streaming for logs on com needs to use `secure: true`, but this was broken recently in our central configs, and production only never broke because we haven't uploaded that config there in the meantime. This patch is meant to be a temporary solution as we're also planning to change Pusher comms to go through private channels only soon.

