### PR TITLE
Rename LOGS_DATABASE_URL to DATABASE_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ $ script/install-sqitch
 To run sqitch, you can run:
 
 ```
-$ script/sqitch-heroku LOGS_DATABASE_URL travis-logs-staging status
+$ script/sqitch-heroku DATABASE_URL travis-logs-staging status
 ```
 
 For more information on how to use sqitch and how to add migrations, you can

--- a/script/enterprise-migrations
+++ b/script/enterprise-migrations
@@ -19,8 +19,8 @@ main() {
     exit 1
   }
 
-  [[ "${LOGS_DATABASE_URL}" ]] || {
-    echo "Missing \$LOGS_DATABASE_URL"
+  [[ "${DATABASE_URL}" ]] || {
+    echo "Missing \$DATABASE_URL"
     exit 1
   }
 
@@ -34,7 +34,7 @@ main() {
     sqitch deploy \
       --to-change structure \
       --log-only \
-      "db:${LOGS_DATABASE_URL}"
+      "db:${DATABASE_URL}"
   fi
   __migrate
 }
@@ -65,17 +65,17 @@ __table_exists_sql() {
 }
 
 __migrate() {
-  # Use the LOGS_DATABASE_URL we use elsewhere but make it fit the DATABASE_URI format
+  # Use the DATABASE_URL we use elsewhere but make it fit the DATABASE_URI format
   # sqitch expects
   sqitch deploy \
     --to-change "${ENTERPRISE_MIGRATE_TO}" \
-    "db:${LOGS_DATABASE_URL}"
+    "db:${DATABASE_URL}"
   sqitch deploy \
     --log-only --no-verify \
-    "db:${LOGS_DATABASE_URL}"
+    "db:${DATABASE_URL}"
   sqitch verify \
     --to-change "${ENTERPRISE_MIGRATE_TO}" \
-    "db:${LOGS_DATABASE_URL}"
+    "db:${DATABASE_URL}"
 }
 
 main "$@"

--- a/script/sqitch-heroku
+++ b/script/sqitch-heroku
@@ -24,8 +24,8 @@ Usage: ${prog} <dbvar> <appname> <sqitch-arg> [sqitch-arg,...]
 
 Examples:
 
-  ${prog} LOGS_DATABASE_URL travis-logs-staging status
-  ${prog} LOGS_DATABASE_URL travis-logs-production verify
+  ${prog} DATABASE_URL travis-logs-staging status
+  ${prog} DATABASE_URL travis-logs-production verify
 
 EOF
 }

--- a/spec/integration/enterprise_migrations_spec.rb
+++ b/spec/integration/enterprise_migrations_spec.rb
@@ -9,7 +9,7 @@ def setup_env_pgdatabase
 end
 
 def setup_env_logs_database_url
-  ENV['LOGS_DATABASE_URL'] = "postgres://localhost:5432/#{dbname}"
+  ENV['DATABASE_URL'] = "postgres://localhost:5432/#{dbname}"
 end
 
 def dbname
@@ -38,7 +38,7 @@ describe 'enterprise-migrations' do
     %w[
       PGHOST
       PGDATABASE
-      LOGS_DATABASE_URL
+      DATABASE_URL
     ].each do |k|
       ENV[k] = nil
     end
@@ -66,7 +66,7 @@ describe 'enterprise-migrations' do
     end
   end
 
-  context 'without LOGS_DATABASE_URL' do
+  context 'without DATABASE_URL' do
     before :each do
       setup_env_pghost
       setup_env_pgdatabase


### PR DESCRIPTION
Please make sure you cover the following points:

### What is the problem that this PR is trying to fix?
The alias for the logs database is currently LOGS_DATABASE in Heroku. This goes against conventions (since heroku expects the primary db to be called `DATABASE`) and makes automating changes (or using the `trvs failover` script harder).

### What approach did you choose and why?
Use DATABASE instead of LOGS_DATABASE as the alias for the Heroku Postgres db and update the references to it in the codebase.

### How can you test this?
Unit tests + deploy to staging.

### What kind of feedback would you like?
I am not sure if this impacts enterprise in any way. For Heroku there shouldn't be any issues, since we have the DATABASE_URL configured for separate apps, but am not sure what the enterprise setup is that regard. (I expect we don't want to reference both the main db and the logs db with the same alias).

