### PR TITLE
rabbitmq multi-ack

### DIFF
--- a/lib/travis/logs/drain_consumer.rb
+++ b/lib/travis/logs/drain_consumer.rb
@@ -123,7 +123,7 @@ module Travis
         batch_buffer.each_pair do |delivery_tag, entry|
           sample[delivery_tag] = entry
         end
-        sample.each_pair do |delivery_tag, entry|  
+        sample.each_pair do |delivery_tag, entry|
           payload.push(entry)
           batch_buffer.delete_pair(delivery_tag, entry)
         end

--- a/lib/travis/logs/drain_consumer.rb
+++ b/lib/travis/logs/drain_consumer.rb
@@ -119,7 +119,8 @@ module Travis
         return ensure_shutdown if dead?
         return if batch_buffer.empty?
         Travis.logger.debug(
-          'flushing batch buffer', size: batch_buffer.size
+          'flushing batch buffer', size: batch_buffer.size,
+                                   consumer: object_id
         )
         sample = {}
         payload = []
@@ -136,7 +137,7 @@ module Travis
           Travis.logger.debug(
             'Ack-ing batch',
             max_delivery_tag: max_delivery_tag,
-            batch: sample.keys
+            batch: sample
           )
           safe_ack(max_delivery_tag, true)
         rescue StandardError => e

--- a/lib/travis/logs/drain_consumer.rb
+++ b/lib/travis/logs/drain_consumer.rb
@@ -117,6 +117,7 @@ module Travis
 
       private def flush_batch_buffer
         return ensure_shutdown if dead?
+        return if batch_buffer.empty?
         Travis.logger.debug(
           'flushing batch buffer', size: batch_buffer.size
         )
@@ -129,7 +130,7 @@ module Travis
           payload.push(entry)
           batch_buffer.delete_pair(delivery_tag, entry)
         end
-        batch_handler.call(payload) unless payload.empty?
+        batch_handler.call(payload)
         begin
           max_delivery_tag = sample.keys.max
           Travis.logger.debug(

--- a/lib/travis/logs/drain_consumer.rb
+++ b/lib/travis/logs/drain_consumer.rb
@@ -135,9 +135,9 @@ module Travis
         begin
           max_delivery_tag = sample.keys.max
           Travis.logger.debug(
-            'Ack-ing batch',
+            'ack-ing batched messages',
             max_delivery_tag: max_delivery_tag,
-            batch: sample
+            consumer: object_id
           )
           safe_ack(max_delivery_tag, true)
         rescue StandardError => e
@@ -159,7 +159,7 @@ module Travis
           pusher_handler.call(decoded_payload)
           batch_buffer[delivery_info.delivery_tag] = decoded_payload
           if batch_buffer.size >= batch_size
-            Travis.logger.debug('Batch size reached. Triggering flush')
+            Travis.logger.debug('batch size reached - triggering flush')
             flush_mutex.synchronize { flush_batch_buffer }
           end
         else


### PR DESCRIPTION
Acknowledge entire batches instead of every single message using rabbit's [multi-ack](https://www.rabbitmq.com/confirms.html#consumer-acks-multiple-parameter) feature.

Our benchmarks in https://github.com/travis-ci/reliability/issues/93 suggest that we can expect this to reduce network traffic and increase throughput alot.

We also found a race condition in the periodic task that would create multiple rabbit connections, which could also explain some strange behaviours we've seen in travis-logs in the past. This has been addressed by initialising the connection early.

refs https://github.com/travis-ci/reliability/issues/123