### PR TITLE
support rabbitmq sharding plugin

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,5 @@
 drain: bundle exec je bin/travis-logs-drain
+drain_sharded: TRAVIS_LOGS_DRAIN_RABBITMQ_SHARDING=true bundle exec je bin/travis-logs-drain
 web: bin/travis-logs-pgbouncer-exec bin/travis-logs-server
 worker_critical: bin/travis-logs-pgbouncer-exec bin/travis-logs-sidekiq -c ${TRAVIS_LOGS_WORKER_CRITICAL_CONCURRENCY:-5} -q logs.pusher_forwarding,1
 worker_high: bin/travis-logs-pgbouncer-exec bin/travis-logs-sidekiq -c ${TRAVIS_LOGS_WORKER_HIGH_CONCURRENCY:-5} -q aggregate,1 -q log_parts,1

--- a/lib/travis/logs/config.rb
+++ b/lib/travis/logs/config.rb
@@ -37,6 +37,7 @@ module Travis
           drain_execution_interval: 3,
           drain_loop_sleep_interval: 10,
           drain_timeout_interval: 3,
+          drain_rabbitmq_sharding: false,
           intervals: {
             aggregate: 60,
             force: 3 * 60 * 60,

--- a/lib/travis/logs/drain.rb
+++ b/lib/travis/logs/drain.rb
@@ -61,7 +61,7 @@ module Travis
 
       private def create_consumer
         Travis::Logs::DrainConsumer.new(
-          'logs',
+          rabbitmq_sharding? ? 'logs_sharded' : 'logs',
           batch_handler: ->(batch) { handle_batch(batch) },
           pusher_handler: ->(payload) { forward_pusher_payload(payload) }
         )
@@ -96,6 +96,10 @@ module Travis
 
       private def loop_sleep_interval
         Travis.config.logs.drain_loop_sleep_interval
+      end
+
+      private def rabbitmq_sharding?
+        Travis.config.logs.drain_rabbitmq_sharding
       end
     end
   end

--- a/lib/travis/logs/drain_consumer.rb
+++ b/lib/travis/logs/drain_consumer.rb
@@ -53,9 +53,23 @@ module Travis
       end
 
       private def jobs_queue
+        return jobs_queue_sharded if logs_config[:drain_rabbitmq_sharding]
+
+        jobs_queue_single
+      end
+
+      private def jobs_queue_single
         @jobs_queue ||= jobs_channel.queue(
           "reporting.jobs.#{reporting_jobs_queue}",
-          durable: true, exclusive: false
+          durable: true, exclusive: false,
+        )
+      end
+
+      private def jobs_queue_sharded
+        @jobs_queue ||= jobs_channel.queue(
+          "reporting.jobs.#{reporting_jobs_queue}",
+          durable: true, exclusive: false,
+          no_declare: true,
         )
       end
 

--- a/lib/travis/logs/drain_consumer.rb
+++ b/lib/travis/logs/drain_consumer.rb
@@ -54,22 +54,20 @@ module Travis
 
       private def jobs_queue
         return jobs_queue_sharded if logs_config[:drain_rabbitmq_sharding]
-
         jobs_queue_single
       end
 
       private def jobs_queue_single
         @jobs_queue ||= jobs_channel.queue(
           "reporting.jobs.#{reporting_jobs_queue}",
-          durable: true, exclusive: false,
+          durable: true, exclusive: false
         )
       end
 
       private def jobs_queue_sharded
         @jobs_queue ||= jobs_channel.queue(
           "reporting.jobs.#{reporting_jobs_queue}",
-          durable: true, exclusive: false,
-          no_declare: true,
+          durable: true, exclusive: false, no_declare: true
         )
       end
 


### PR DESCRIPTION
In order to support [rabbitmq-sharding](https://github.com/rabbitmq/rabbitmq-sharding), we need to make sure to skip declaring the sharded queue (https://github.com/rabbitmq/rabbitmq-sharding/issues/20). The sharding plugin only works if the queue does not exist, it will then dynamically assign the virtual queue to one of the shards for each consumer.

This also switches between `reporting.jobs.logs` and `reporting.jobs.logs_sharded` as queue names depending on whether sharding is enabled.

Ultimately, the goal is to spread load more evenly across cpus and nodes.

refs https://github.com/travis-ci/reliability/issues/124