### PR TITLE
move all of the rabbitmq sharding logic to drain consumer

### DIFF
--- a/lib/travis/logs/drain.rb
+++ b/lib/travis/logs/drain.rb
@@ -61,7 +61,6 @@ module Travis
 
       private def create_consumer
         Travis::Logs::DrainConsumer.new(
-          rabbitmq_sharding? ? 'logs_sharded' : 'logs',
           batch_handler: ->(batch) { handle_batch(batch) },
           pusher_handler: ->(payload) { forward_pusher_payload(payload) }
         )
@@ -96,10 +95,6 @@ module Travis
 
       private def loop_sleep_interval
         Travis.config.logs.drain_loop_sleep_interval
-      end
-
-      private def rabbitmq_sharding?
-        Travis.config.logs.drain_rabbitmq_sharding
       end
     end
   end

--- a/lib/travis/logs/drain_consumer.rb
+++ b/lib/travis/logs/drain_consumer.rb
@@ -27,11 +27,9 @@ module Travis
       private :pusher_handler
       private :periodic_flush_task
 
-      def initialize(reporting_jobs_queue, batch_handler: nil,
-                     pusher_handler: nil)
+      def initialize(batch_handler: nil, pusher_handler: nil)
         @batch_buffer = Concurrent::Map.new
         @flush_mutex = Mutex.new
-        @reporting_jobs_queue = reporting_jobs_queue
         @batch_handler = batch_handler
         @pusher_handler = pusher_handler
 
@@ -69,14 +67,14 @@ module Travis
 
       private def jobs_queue_single
         @jobs_queue ||= jobs_channel.queue(
-          "reporting.jobs.#{reporting_jobs_queue}",
+          'reporting.jobs.logs',
           durable: true, exclusive: false
         )
       end
 
       private def jobs_queue_sharded
         @jobs_queue ||= jobs_channel.queue(
-          "reporting.jobs.#{reporting_jobs_queue}",
+          'reporting.jobs.logs_sharded',
           durable: true, exclusive: false, no_declare: true
         )
       end

--- a/spec/integration/drain_spec.rb
+++ b/spec/integration/drain_spec.rb
@@ -27,7 +27,6 @@ describe 'receive_logs' do
     pusher_payloads = []
 
     dq = Travis::Logs::DrainConsumer.new(
-      'logs',
       batch_handler: ->(b) { batches << b },
       pusher_handler: ->(p) { pusher_payloads << p }
     )


### PR DESCRIPTION
Follow-up to #181. This should make it clearer where the queue name comes from, and how the switch between `logs` and `logs_sharded` happens.

I've kept the `reporting.jobs.` prefix in for now, it might make it easier during the rollout (thinking of lists sorted by name), but we can definitely consider removing it. 👍 

refs travis-ci/reliability#124