### PR TITLE
Add a delay between consumer subscribes

### DIFF
--- a/lib/travis/logs/drain.rb
+++ b/lib/travis/logs/drain.rb
@@ -34,7 +34,7 @@ module Travis
           consumer.subscribe
           # delay is needed to ensure a balanced distribution of consumers to
           # sharded queues
-          sleep(rand(1..3))
+          sleep(rand(1..3)) if rabbitmq_sharding?
         end
 
         return run_loop_tick if once
@@ -57,7 +57,7 @@ module Travis
           consumers[name].subscribe
           # delay is needed to ensure a balanced distribution of consumers to
           # sharded queues
-          sleep(rand(1..3))
+          sleep(rand(1..3)) if rabbitmq_sharding?
         end
 
         sleep(loop_sleep_interval)

--- a/lib/travis/logs/drain.rb
+++ b/lib/travis/logs/drain.rb
@@ -30,7 +30,12 @@ module Travis
           consumers["#{n}/#{consumer_count}"] = create_consumer
         end
 
-        consumers.each_pair { |_, consumer| consumer.subscribe }
+        consumers.each_pair do |_, consumer|
+          consumer.subscribe
+          # delay is needed to ensure a balanced distribution of consumers to
+          # sharded queues
+          sleep(rand(1..3))
+        end
 
         return run_loop_tick if once
         loop { run_loop_tick }
@@ -50,6 +55,9 @@ module Travis
           Travis.logger.debug('creating new consumer', name: name)
           consumers[name] = create_consumer
           consumers[name].subscribe
+          # delay is needed to ensure a balanced distribution of consumers to
+          # sharded queues
+          sleep(rand(1..3))
         end
 
         sleep(loop_sleep_interval)

--- a/lib/travis/logs/drain.rb
+++ b/lib/travis/logs/drain.rb
@@ -104,6 +104,10 @@ module Travis
       private def loop_sleep_interval
         Travis.config.logs.drain_loop_sleep_interval
       end
+
+      private def rabbitmq_sharding?
+        Travis.config.logs.drain_rabbitmq_sharding
+      end
     end
   end
 end


### PR DESCRIPTION
### What is the problem that this PR is trying to fix?
https://github.com/travis-ci/reliability/issues/132

### What approach did you choose and why?
Added a random delay when subscribing multiple consumers to the queue.

### How can you test this?
Unfortunately, since we only run RabbitMQ in HA mode in production, this should only be visible there (and with a higher numbers of drains), but since the scope of the change is small, I don't think it is very risky.
