### PR TITLE
Make the max value for the random consumer restart interval configurable

### DIFF
--- a/lib/travis/logs/drain.rb
+++ b/lib/travis/logs/drain.rb
@@ -7,7 +7,6 @@ require 'travis/metrics'
 module Travis
   module Logs
     class Drain
-
       MAX_RESTART_INTERVAL = ENV['MAX_CONSUMER_RESTART_INTERVAL']&.to_i || 5
 
       def self.setup

--- a/lib/travis/logs/drain.rb
+++ b/lib/travis/logs/drain.rb
@@ -7,6 +7,9 @@ require 'travis/metrics'
 module Travis
   module Logs
     class Drain
+
+      MAX_RESTART_INTERVAL = ENV['MAX_CONSUMER_RESTART_INTERVAL']&.to_i || 5
+
       def self.setup
         return if defined?(@setup)
         Travis.logger.debug('setting up drain dependencies')
@@ -34,7 +37,7 @@ module Travis
           consumer.subscribe
           # delay is needed to ensure a balanced distribution of consumers to
           # sharded queues
-          sleep(rand(1..3)) if rabbitmq_sharding?
+          sleep(rand(1..MAX_RESTART_INTERVAL)) if rabbitmq_sharding?
         end
 
         return run_loop_tick if once
@@ -57,7 +60,7 @@ module Travis
           consumers[name].subscribe
           # delay is needed to ensure a balanced distribution of consumers to
           # sharded queues
-          sleep(rand(1..3)) if rabbitmq_sharding?
+          sleep(rand(1..MAX_RESTART_INTERVAL)) if rabbitmq_sharding?
         end
 
         sleep(loop_sleep_interval)


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
The current restart policy still causes the consumers to be unbalanced every now and then.

## What approach did you choose and why?
Make the max value for the interval configurable, so we could experiment with higher values.

