### PR TITLE
make min interval configurable also

### DIFF
--- a/lib/travis/logs/drain.rb
+++ b/lib/travis/logs/drain.rb
@@ -7,6 +7,7 @@ require 'travis/metrics'
 module Travis
   module Logs
     class Drain
+      MIN_RESTART_INTERVAL = ENV['MIN_CONSUMER_RESTART_INTERVAL']&.to_i || 1
       MAX_RESTART_INTERVAL = ENV['MAX_CONSUMER_RESTART_INTERVAL']&.to_i || 5
 
       def self.setup
@@ -36,7 +37,7 @@ module Travis
           consumer.subscribe
           # delay is needed to ensure a balanced distribution of consumers to
           # sharded queues
-          sleep(rand(1..MAX_RESTART_INTERVAL)) if rabbitmq_sharding?
+          sleep(rand(MIN_RESTART_INTERVAL..MAX_RESTART_INTERVAL)) if rabbitmq_sharding?
         end
 
         return run_loop_tick if once


### PR DESCRIPTION
We're still seeing some uneven distribution of consumers. This is to allow raising the minimum sleep interval from 1 second.

refs #185