### PR TITLE
drain: rename consumer restart interval env vars

### DIFF
--- a/lib/travis/logs/drain.rb
+++ b/lib/travis/logs/drain.rb
@@ -61,7 +61,7 @@ module Travis
           consumers[name].subscribe
           # delay is needed to ensure a balanced distribution of consumers to
           # sharded queues
-          sleep(rand(1..MAX_RESTART_INTERVAL)) if rabbitmq_sharding?
+          sleep(rand(MIN_RESTART_INTERVAL..MAX_RESTART_INTERVAL)) if rabbitmq_sharding?
         end
 
         sleep(loop_sleep_interval)

--- a/lib/travis/logs/drain.rb
+++ b/lib/travis/logs/drain.rb
@@ -61,7 +61,8 @@ module Travis
           consumers[name].subscribe
           # delay is needed to ensure a balanced distribution of consumers to
           # sharded queues
-          sleep(rand(RESTART_INTERVAL_MIN..RESTART_INTERVAL_MAX)) if rabbitmq_sharding?
+          interval = rand(RESTART_INTERVAL_MIN..RESTART_INTERVAL_MAX)
+          sleep(interval) if rabbitmq_sharding?
         end
 
         sleep(loop_sleep_interval)

--- a/lib/travis/logs/drain.rb
+++ b/lib/travis/logs/drain.rb
@@ -7,8 +7,8 @@ require 'travis/metrics'
 module Travis
   module Logs
     class Drain
-      MIN_RESTART_INTERVAL = ENV['MIN_CONSUMER_RESTART_INTERVAL']&.to_f || 1.0
-      MAX_RESTART_INTERVAL = ENV['MAX_CONSUMER_RESTART_INTERVAL']&.to_f || 5.0
+      RESTART_INTERVAL_MIN = ENV['CONSUMER_RESTART_INTERVAL_MIN']&.to_f || 1.0
+      RESTART_INTERVAL_MAX = ENV['CONSUMER_RESTART_INTERVAL_MAX']&.to_f || 5.0
 
       def self.setup
         return if defined?(@setup)
@@ -37,7 +37,7 @@ module Travis
           consumer.subscribe
           # delay is needed to ensure a balanced distribution of consumers to
           # sharded queues
-          interval = rand(MIN_RESTART_INTERVAL..MAX_RESTART_INTERVAL)
+          interval = rand(RESTART_INTERVAL_MIN..RESTART_INTERVAL_MAX)
           sleep(interval) if rabbitmq_sharding?
         end
 
@@ -61,7 +61,7 @@ module Travis
           consumers[name].subscribe
           # delay is needed to ensure a balanced distribution of consumers to
           # sharded queues
-          sleep(rand(MIN_RESTART_INTERVAL..MAX_RESTART_INTERVAL)) if rabbitmq_sharding?
+          sleep(rand(RESTART_INTERVAL_MIN..RESTART_INTERVAL_MAX)) if rabbitmq_sharding?
         end
 
         sleep(loop_sleep_interval)


### PR DESCRIPTION
After the introduction of a separate `MIN` variable (https://github.com/travis-ci/travis-logs/pull/186), the vars now do not share a common prefix. This moves `MIN|MAX` to the end of the env var name.

Also, in one of the locations the minimum was still hardcoded to `1`.

Before this is rolled out the following is needed:

```
heroku config:set CONSUMER_RESTART_INTERVAL_MIN="$(heroku config:get MIN_CONSUMER_RESTART_INTERVAL)"
heroku config:set CONSUMER_RESTART_INTERVAL_MAX="$(heroku config:get MAX_CONSUMER_RESTART_INTERVAL)"
```

After rollout:

```
heroku config:unset MIN_CONSUMER_RESTART_INTERVAL MAX_CONSUMER_RESTART_INTERVAL
```