### PR TITLE
track time to first log line in honeycomb

### DIFF
--- a/lib/travis/logs/pusher.rb
+++ b/lib/travis/logs/pusher.rb
@@ -25,6 +25,11 @@ module Travis
           Metriks.timer('logs.time_to_first_log_line.pusher').update(elapsed)
           Metriks.timer("logs.time_to_first_log_line.infra.#{meta['infra']}.pusher").update(elapsed)
           Metriks.timer("logs.time_to_first_log_line.queue.#{meta['queue']}.pusher").update(elapsed)
+          Travis::Honeycomb.context.merge({
+            time_to_first_log_line_pusher_ms: elapsed * 1000,
+            infra: meta['infra'],
+            queue: meta['queue'],
+          })
         end
       end
 

--- a/lib/travis/logs/pusher.rb
+++ b/lib/travis/logs/pusher.rb
@@ -25,11 +25,11 @@ module Travis
           Metriks.timer('logs.time_to_first_log_line.pusher').update(elapsed)
           Metriks.timer("logs.time_to_first_log_line.infra.#{meta['infra']}.pusher").update(elapsed)
           Metriks.timer("logs.time_to_first_log_line.queue.#{meta['queue']}.pusher").update(elapsed)
-          Travis::Honeycomb.context.merge({
+          Travis::Honeycomb.context.merge(
             time_to_first_log_line_pusher_ms: elapsed * 1000,
             infra: meta['infra'],
-            queue: meta['queue'],
-          })
+            queue: meta['queue']
+          )
         end
       end
 


### PR DESCRIPTION
We currently track it in librato, but it would be good to have this data in honeycomb for more slicing and dicing along various dimensions.