### PR TITLE
always sample time to first log line

### DIFF
--- a/lib/travis/logs/pusher.rb
+++ b/lib/travis/logs/pusher.rb
@@ -25,6 +25,7 @@ module Travis
           Metriks.timer('logs.time_to_first_log_line.pusher').update(elapsed)
           Metriks.timer("logs.time_to_first_log_line.infra.#{meta['infra']}.pusher").update(elapsed)
           Metriks.timer("logs.time_to_first_log_line.queue.#{meta['queue']}.pusher").update(elapsed)
+          Travis::Honeycomb.always_sample!
           Travis::Honeycomb.context.merge({
             time_to_first_log_line_pusher_ms: elapsed * 1000,
             infra: meta['infra'],


### PR DESCRIPTION
Follow-up to #196. The change was missing due to GitHub issues yesterday. Guessing the push didn't go through.