### PR TITLE
track time-to-first-log-line for log parts

### DIFF
--- a/lib/travis/logs/log_parts_writer.rb
+++ b/lib/travis/logs/log_parts_writer.rb
@@ -45,6 +45,25 @@ module Travis
             entry['log'].bytesize
           }.reduce(&:+))
 
+          # NOTE: if we have multiple payloads per batch, then we might
+          #       only store the metadata for the last one in honeycomb.
+          normalized.map do |_, entry|
+            if entry['meta']
+              meta = payload['meta']
+              elapsed = Time.now - Time.parse(meta['queued_at'])
+              Metriks.timer('logs.time_to_first_log_line.log_parts').update(elapsed)
+              Metriks.timer("logs.time_to_first_log_line.infra.#{meta['infra']}.log_parts").update(elapsed)
+              Metriks.timer("logs.time_to_first_log_line.queue.#{meta['queue']}.log_parts").update(elapsed)
+              Travis::Honeycomb.always_sample!
+              Travis::Honeycomb.context.merge(
+                time_to_first_log_line_log_parts_ms: elapsed * 1000,
+                infra: meta['infra'],
+                queue: meta['queue'],
+                repo:  meta['repo']
+              )
+            end
+          end
+
           create_parts(
             normalized
           )

--- a/lib/travis/logs/log_parts_writer.rb
+++ b/lib/travis/logs/log_parts_writer.rb
@@ -45,9 +45,13 @@ module Travis
             entry['log'].bytesize
           }.reduce(&:+))
 
+          parts = create_parts(
+            normalized
+          )
+
           # NOTE: if we have multiple payloads per batch, then we might
           #       only store the metadata for the last one in honeycomb.
-          normalized.map do |_, entry|
+          normalized.each do |_, entry|
             if entry['meta']
               meta = payload['meta']
               elapsed = Time.now - Time.parse(meta['queued_at'])
@@ -64,9 +68,7 @@ module Travis
             end
           end
 
-          create_parts(
-            normalized
-          )
+          parts
         end
       end
 


### PR DESCRIPTION
We currently are tracking time-to-first-log-line for pusher notifications. This is only a small subset though, since we only deliver those to users who are viewing the site.

In addition, we should also track this metric for when the log parts make it to the database. This will give us wider coverage, and is also an indicator for other bottlenecks that impact user experience.