### PR TITLE
honeycomb: introduce custom sample rate for log_parts time-to-first-log-line

### DIFF
--- a/lib/travis/honeycomb.rb
+++ b/lib/travis/honeycomb.rb
@@ -46,10 +46,10 @@ module Travis
 
         if context.always_sample?
           ev.sample_rate = 1
-          ev.send_presampled
-        else
-          ev.send
+        elsif context.sample_rate
+          ev.sample_rate = context.sample_rate
         end
+        ev.send
       end
 
       def honey

--- a/lib/travis/honeycomb/context.rb
+++ b/lib/travis/honeycomb/context.rb
@@ -12,16 +12,20 @@ module Travis
         end
       end
 
+      attr_accessor :sample_rate
+
       def initialize
         @tags = {}
         @data = {}
         @always_sample = false
+        @sample_rate = nil
       end
 
       def clear
         @tags = {}
         @data = {}
         @always_sample = false
+        @sample_rate = nil
       end
 
       def tag(key, value)

--- a/lib/travis/logs/log_parts_writer.rb
+++ b/lib/travis/logs/log_parts_writer.rb
@@ -59,7 +59,7 @@ module Travis
             Metriks.timer('logs.time_to_first_log_line.log_parts').update(elapsed)
             Metriks.timer("logs.time_to_first_log_line.infra.#{meta['infra']}.log_parts").update(elapsed)
             Metriks.timer("logs.time_to_first_log_line.queue.#{meta['queue']}.log_parts").update(elapsed)
-            Travis::Honeycomb.sample_rate = ENV['HONEYCOMB_SAMPLE_RATE_TTFLL_LOG_PARTS']&.to_i || 1
+            Travis::Honeycomb.context.sample_rate = ENV['HONEYCOMB_SAMPLE_RATE_TTFLL_LOG_PARTS']&.to_i || 1
             Travis::Honeycomb.context.merge(
               time_to_first_log_line_log_parts_ms: elapsed * 1000,
               infra: meta['infra'],

--- a/lib/travis/logs/log_parts_writer.rb
+++ b/lib/travis/logs/log_parts_writer.rb
@@ -59,7 +59,7 @@ module Travis
             Metriks.timer('logs.time_to_first_log_line.log_parts').update(elapsed)
             Metriks.timer("logs.time_to_first_log_line.infra.#{meta['infra']}.log_parts").update(elapsed)
             Metriks.timer("logs.time_to_first_log_line.queue.#{meta['queue']}.log_parts").update(elapsed)
-            Travis::Honeycomb.always_sample!
+            Travis::Honeycomb.sample_rate = ENV['HONEYCOMB_SAMPLE_RATE_TTFLL_LOG_PARTS']&.to_i || 1
             Travis::Honeycomb.context.merge(
               time_to_first_log_line_log_parts_ms: elapsed * 1000,
               infra: meta['infra'],


### PR DESCRIPTION
Sampling every event is a bit too much. It's spamming our honeycomb dataset. This gives us more flexibility and allows us to sample most events at a rate of 1/5000 or so, and these more high-information ones at maybe 1/10.

This can be done by setting the `HONEYCOMB_SAMPLE_RATE_TTFLL_LOG_PARTS` environment variable.

For example:

```
heroku config:set HONEYCOMB_SAMPLE_RATE_TTFLL_LOG_PARTS=10
```