### PR TITLE
revert hdrhistogram dependency to previous version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    HDRHistogram (0.1.7)
+    HDRHistogram (0.1.3)
     activesupport (5.2.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)


### PR DESCRIPTION
The api of `HDRHistogram` changed from `merge` to `merge!`, which broke metrics. The deps update was introduced by https://github.com/travis-ci/travis-logs/pull/200.

Updating the library proper will also require an update to [`travis-ci/metriks`](http://github.com/travis-ci/metriks).