### PR TITLE
check for nullable created_at in log_parts table

### DIFF
--- a/script/enterprise-migrations
+++ b/script/enterprise-migrations
@@ -36,7 +36,10 @@ main() {
       --log-only \
       "db:${DATABASE_URL}"
   fi
-  __migrate
+
+  if __logparts_created_at_nullable; then
+    __migrate
+  fi
 }
 
 __pgdb_exists() {
@@ -62,6 +65,23 @@ __logs_tables_exist() {
 __table_exists_sql() {
   echo "SELECT 1/count(*) FROM pg_catalog.pg_tables " \
     "WHERE schemaname = 'public' AND tablename = '${1}'"
+}
+
+__logparts_created_at_nullable() {
+  psql -c "$(__logparts_created_at_nullable_sql)" | if ! grep -q "no"; then
+    return 1
+  fi
+
+  psql -c "$(__logparts_created_at_nullable_sql)" | if ! grep -q "timestamp"; then
+    return 1
+  fi
+
+  return 0
+}
+
+__logparts_created_at_nullable_sql() {
+  echo "SELECT data_type, is_nullable FROM information_schema.columns " \
+    "WHERE table_name = 'log_parts' AND column_name = 'created_at'"
 }
 
 __migrate() {

--- a/script/enterprise-migrations
+++ b/script/enterprise-migrations
@@ -40,7 +40,7 @@ main() {
     fi
   fi
   echo "Before Test Migrate"
-  psql -c "$(__logparts_created_at_nullable_sql)" | if ! grep -qE "NO|timestamp"; then
+  sqitch verify --to-change "${ENTERPRISE_MIGRATE_TO}" "db:${DATABASE_URL}" | if ! grep -qE "Verify successful"; then
     echo "Test Migrate"
     __migrate
   else

--- a/script/enterprise-migrations
+++ b/script/enterprise-migrations
@@ -25,6 +25,12 @@ main() {
   }
 
   : "${ENTERPRISE_MIGRATE_TO:=log_parts_created_at_not_null}"
+  
+  echo "Before sqitch_verify Migrate"
+  sqitch verify --to-change "${ENTERPRISE_MIGRATE_TO}" "db:${DATABASE_URL}" | if grep -qE "Verify successful" then
+    echo "sqitch_verify Migrate"
+    exit 0
+  fi
 
   if ! __pgdb_exists; then
     createdb

--- a/script/enterprise-migrations
+++ b/script/enterprise-migrations
@@ -40,7 +40,7 @@ main() {
     fi
   fi
   echo "Before Test Migrate"
-  psql -c "$(__logparts_created_at_nullable_sql)" | if ! grep -qE "NO"; then
+  psql -c "$(__logparts_created_at_nullable_sql)" | if ! grep -qE "NO|timestamp"; then
     echo "Test Migrate"
     __migrate
   else

--- a/script/enterprise-migrations
+++ b/script/enterprise-migrations
@@ -40,6 +40,9 @@ main() {
   if __logparts_created_at_nullable; then
     echo "Test Migrate"
     __migrate
+  else
+    sqitch verify \
+    "db:${DATABASE_URL}"
   fi
 }
 

--- a/script/enterprise-migrations
+++ b/script/enterprise-migrations
@@ -26,30 +26,26 @@ main() {
 
   : "${ENTERPRISE_MIGRATE_TO:=log_parts_created_at_not_null}"
   
-  echo "Before sqitch_verify Migrate"
-  sqitch verify --to-change "${ENTERPRISE_MIGRATE_TO}" "db:${DATABASE_URL}" | if grep -qE "Verify successful" then
-    echo "sqitch_verify Migrate"
-    exit 0
-  fi
-
   if ! __pgdb_exists; then
     createdb
   fi
   echo "Before __logs_tables_exist Migrate"
   if __logs_tables_exist; then
   echo "__logs_tables_exist Migrate"
-    sqitch deploy \
-      --to-change structure \
-      --log-only \
-      "db:${DATABASE_URL}"
+  echo "Before sqitch_verify Migrate"
+    sqitch verify --to-change "${ENTERPRISE_MIGRATE_TO}" "db:${DATABASE_URL}" | if ! grep -qE "Verify successful" then
+      sqitch deploy \
+        --to-change structure \
+        --log-only \
+        "db:${DATABASE_URL}"
+    fi
   fi
   echo "Before Test Migrate"
   if __logparts_created_at_nullable; then
     echo "Test Migrate"
     __migrate
   else
-    sqitch verify \
-    "db:${DATABASE_URL}"
+    sqitch verify --to-change "${ENTERPRISE_MIGRATE_TO}" "db:${DATABASE_URL}"
   fi
 }
 

--- a/script/enterprise-migrations
+++ b/script/enterprise-migrations
@@ -75,11 +75,14 @@ __table_exists_sql() {
 }
 
 __logparts_created_at_nullable() {
+  psql -c "$(__logparts_created_at_nullable_sql)"
   psql -c "$(__logparts_created_at_nullable_sql)" | if ! grep -q "no"; then
+    echo "no not found"
     return 1
   fi
 
   psql -c "$(__logparts_created_at_nullable_sql)" | if ! grep -q "timestamp"; then
+    echo "timestamp not found"
     return 1
   fi
 

--- a/script/enterprise-migrations
+++ b/script/enterprise-migrations
@@ -76,12 +76,12 @@ __table_exists_sql() {
 
 __logparts_created_at_nullable() {
   psql -c "$(__logparts_created_at_nullable_sql)"
-  psql -c "$(__logparts_created_at_nullable_sql)" | if ! grep -q "no"; then
+  psql -c "$(__logparts_created_at_nullable_sql)" | if ! grep "NO"; then
     echo "no not found"
     return 1
   fi
 
-  psql -c "$(__logparts_created_at_nullable_sql)" | if ! grep -q "timestamp"; then
+  psql -c "$(__logparts_created_at_nullable_sql)" | if ! grep "timestamp"; then
     echo "timestamp not found"
     return 1
   fi

--- a/script/enterprise-migrations
+++ b/script/enterprise-migrations
@@ -33,7 +33,7 @@ main() {
   if __logs_tables_exist; then
   echo "__logs_tables_exist Migrate"
   echo "Before sqitch_verify Migrate"
-    sqitch verify --to-change "${ENTERPRISE_MIGRATE_TO}" "db:${DATABASE_URL}" | if ! grep -qE "Verify successful" then
+    sqitch verify --to-change structure "db:${DATABASE_URL}" | if ! grep -qE "Verify successful" then
       sqitch deploy \
         --to-change structure \
         --log-only \

--- a/script/enterprise-migrations
+++ b/script/enterprise-migrations
@@ -25,13 +25,12 @@ main() {
   }
 
   : "${ENTERPRISE_MIGRATE_TO:=log_parts_created_at_not_null}"
-  
+
   if ! __pgdb_exists; then
     createdb
   fi
-  echo "Before __logs_tables_exist Migrate"
+
   if __logs_tables_exist; then
-    echo "Before sqitch_verify Migrate"
     sqitch verify --to-change structure "db:${DATABASE_URL}" | if ! grep -qE "Verify successful"; then
       sqitch deploy \
         --to-change structure \
@@ -39,9 +38,8 @@ main() {
         "db:${DATABASE_URL}"
     fi
   fi
-  echo "Before Test Migrate"
+
   sqitch verify --to-change "${ENTERPRISE_MIGRATE_TO}" "db:${DATABASE_URL}" | if ! grep -qE "Verify successful"; then
-    echo "Test Migrate"
     __migrate
   else
     sqitch verify --to-change "${ENTERPRISE_MIGRATE_TO}" "db:${DATABASE_URL}"
@@ -71,11 +69,6 @@ __logs_tables_exist() {
 __table_exists_sql() {
   echo "SELECT 1/count(*) FROM pg_catalog.pg_tables " \
     "WHERE schemaname = 'public' AND tablename = '${1}'"
-}
-
-__logparts_created_at_nullable_sql() {
-  echo "SELECT data_type, is_nullable FROM information_schema.columns " \
-    "WHERE table_name = 'log_parts' AND column_name = 'created_at'"
 }
 
 __migrate() {

--- a/script/enterprise-migrations
+++ b/script/enterprise-migrations
@@ -5,7 +5,7 @@ main() {
   if [[ "${DEBUG}" ]]; then
     set -o xtrace
   fi
-  echo "path"
+  
   PATH="${HOME}/bin:${PATH}"
   eval "$(perl -I ~/perl5/lib/perl5/ '-Mlocal::lib')"
 

--- a/script/enterprise-migrations
+++ b/script/enterprise-migrations
@@ -31,8 +31,7 @@ main() {
   fi
   echo "Before __logs_tables_exist Migrate"
   if __logs_tables_exist; then
-  echo "__logs_tables_exist Migrate"
-  echo "Before sqitch_verify Migrate"
+    echo "Before sqitch_verify Migrate"
     sqitch verify --to-change structure "db:${DATABASE_URL}" | if ! grep -qE "Verify successful"; then
       sqitch deploy \
         --to-change structure \
@@ -41,8 +40,7 @@ main() {
     fi
   fi
   echo "Before Test Migrate"
-  echo __logparts_created_at_nullable
-  if __logparts_created_at_nullable; then
+  psql -c "$(__logparts_created_at_nullable_sql)" | if ! grep -qE "NO|timestamp"; then
     echo "Test Migrate"
     __migrate
   else
@@ -73,21 +71,6 @@ __logs_tables_exist() {
 __table_exists_sql() {
   echo "SELECT 1/count(*) FROM pg_catalog.pg_tables " \
     "WHERE schemaname = 'public' AND tablename = '${1}'"
-}
-
-__logparts_created_at_nullable() {
-  psql -c "$(__logparts_created_at_nullable_sql)" | ! grep -qE "NO"
-  psql -c "$(__logparts_created_at_nullable_sql)" | if ! grep -qE "NO"; then
-    echo "no not found"
-    return 1
-  fi
-  psql -c "$(__logparts_created_at_nullable_sql)" | ! grep -qE "timestamp"
-  psql -c "$(__logparts_created_at_nullable_sql)" | if ! grep -qE "timestamp"; then
-    echo "timestamp not found"
-    return 1
-  fi
-
-  return 0
 }
 
 __logparts_created_at_nullable_sql() {

--- a/script/enterprise-migrations
+++ b/script/enterprise-migrations
@@ -41,6 +41,7 @@ main() {
     fi
   fi
   echo "Before Test Migrate"
+  echo __logparts_created_at_nullable
   if __logparts_created_at_nullable; then
     echo "Test Migrate"
     __migrate
@@ -75,13 +76,13 @@ __table_exists_sql() {
 }
 
 __logparts_created_at_nullable() {
-  psql -c "$(__logparts_created_at_nullable_sql)"
-  psql -c "$(__logparts_created_at_nullable_sql)" | if ! grep "NO"; then
+  psql -c "$(__logparts_created_at_nullable_sql)" | ! grep -qE "NO"
+  psql -c "$(__logparts_created_at_nullable_sql)" | if ! grep -qE "NO"; then
     echo "no not found"
     return 1
   fi
-
-  psql -c "$(__logparts_created_at_nullable_sql)" | if ! grep "timestamp"; then
+  psql -c "$(__logparts_created_at_nullable_sql)" | ! grep -qE "timestamp"
+  psql -c "$(__logparts_created_at_nullable_sql)" | if ! grep -qE "timestamp"; then
     echo "timestamp not found"
     return 1
   fi

--- a/script/enterprise-migrations
+++ b/script/enterprise-migrations
@@ -40,7 +40,7 @@ main() {
     fi
   fi
   echo "Before Test Migrate"
-  psql -c "$(__logparts_created_at_nullable_sql)" | if ! grep -qE "NO|timestamp"; then
+  psql -c "$(__logparts_created_at_nullable_sql)" | if ! grep -qE "NO"; then
     echo "Test Migrate"
     __migrate
   else
@@ -91,5 +91,5 @@ __migrate() {
     --to-change "${ENTERPRISE_MIGRATE_TO}" \
     "db:${DATABASE_URL}"
 }
-echo "Test"
+
 main "$@"

--- a/script/enterprise-migrations
+++ b/script/enterprise-migrations
@@ -36,8 +36,9 @@ main() {
       --log-only \
       "db:${DATABASE_URL}"
   fi
-
+  echo "Before Test Migrate"
   if __logparts_created_at_nullable; then
+    echo "Test Migrate"
     __migrate
   fi
 }

--- a/script/enterprise-migrations
+++ b/script/enterprise-migrations
@@ -5,7 +5,7 @@ main() {
   if [[ "${DEBUG}" ]]; then
     set -o xtrace
   fi
-
+  echo "path"
   PATH="${HOME}/bin:${PATH}"
   eval "$(perl -I ~/perl5/lib/perl5/ '-Mlocal::lib')"
 
@@ -29,8 +29,9 @@ main() {
   if ! __pgdb_exists; then
     createdb
   fi
-
+  echo "Before __logs_tables_exist Migrate"
   if __logs_tables_exist; then
+  echo "__logs_tables_exist Migrate"
     sqitch deploy \
       --to-change structure \
       --log-only \
@@ -101,5 +102,5 @@ __migrate() {
     --to-change "${ENTERPRISE_MIGRATE_TO}" \
     "db:${DATABASE_URL}"
 }
-
+echo "Test"
 main "$@"

--- a/script/enterprise-migrations
+++ b/script/enterprise-migrations
@@ -33,7 +33,7 @@ main() {
   if __logs_tables_exist; then
   echo "__logs_tables_exist Migrate"
   echo "Before sqitch_verify Migrate"
-    sqitch verify --to-change structure "db:${DATABASE_URL}" | if ! grep -qE "Verify successful" then
+    sqitch verify --to-change structure "db:${DATABASE_URL}" | if ! grep -qE "Verify successful"; then
       sqitch deploy \
         --to-change structure \
         --log-only \

--- a/script/enterprise-migrations
+++ b/script/enterprise-migrations
@@ -5,7 +5,7 @@ main() {
   if [[ "${DEBUG}" ]]; then
     set -o xtrace
   fi
-  
+
   PATH="${HOME}/bin:${PATH}"
   eval "$(perl -I ~/perl5/lib/perl5/ '-Mlocal::lib')"
 


### PR DESCRIPTION
Please make sure you cover the following points:

1. What is the problem that this PR is trying to fix?

TCI E k8s - If you update travis-logs tag, then it rerun the 'log_parts_created_at_not_null.sql'. We should have a check if it is already exists.

2. What approach did you choose and why?

We verify the column attributes with information schema of Postgresql.

3. How can you test this?

Applying the latest tag of travis-log and check the logs of k8s travis-logs pod.

(4. What feedback would you like?)

I expect this will not effect hosted solution and fix the existing issue.

Ref: https://travisci.assembla.com/spaces/Enterprise/tickets/realtime_list?ticket=73