### PR TITLE
Reduce logs purge interval

### DIFF
--- a/lib/travis/logs/config.rb
+++ b/lib/travis/logs/config.rb
@@ -50,7 +50,7 @@ module Travis
           intervals: {
             aggregate: 60,
             force: 3 * 60 * 60,
-            purge: 6,
+            purge: 2,
             regular: 3 * 60,
             timing_info: 60,
             sweeper: 10 * 60


### PR DESCRIPTION
Please make sure you cover the following points:

1. What is the problem that this PR is trying to fix?
Reduce logs DB storage size

2. What approach did you choose and why?
Reduce purge delay from 6 to 2 hours

3. How can you test this?
Deploy and check DB

(4. What feedback would you like?)
