### PR TITLE
redis workaround for CLIENT command

### DIFF
--- a/lib/travis/logs/sidekiq.rb
+++ b/lib/travis/logs/sidekiq.rb
@@ -28,7 +28,8 @@ module Travis
           ::Sidekiq.redis = ::Sidekiq::RedisConnection.create(
             url: Travis.config.redis.url,
             namespace: Travis.config.sidekiq.namespace,
-            size: Travis.config.sidekiq.pool_size
+            size: Travis.config.sidekiq.pool_size,
+            id: nil
           )
           ::Sidekiq.logger = sidekiq_logger
           ::Sidekiq.configure_server do |config|


### PR DESCRIPTION
Redis at GCE does not allow CLIENT command and it's common behavior of Sidekiq, so we have to set id of redis connection to nil to not name it.