### PR TITLE
redis workaround for CLIENT command timeout

### DIFF
--- a/lib/travis/logs/sidekiq.rb
+++ b/lib/travis/logs/sidekiq.rb
@@ -26,7 +26,8 @@ module Travis
           ::Sidekiq.redis = ::Sidekiq::RedisConnection.create(
             url: Travis.config.redis.url,
             namespace: Travis.config.sidekiq.namespace,
-            size: Travis.config.sidekiq.pool_size
+            size: Travis.config.sidekiq.pool_size,
+            id: nil
           )
           ::Sidekiq.logger = sidekiq_logger
           ::Sidekiq.configure_server do |config|


### PR DESCRIPTION
Please make sure you cover the following points:

1. What is the problem that this PR is trying to fix?
redis workaround for CLIENT command timeout.
2. What approach did you choose and why?
set id: nil to not send server the CLIENT cmd.
3. How can you test this?
on enterprise 2.2
(4. What feedback would you like?)
