### PR TITLE
Fix for missing Redis class

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'rack-test', group: :test
 gem 'rake'
 gem 'rbtrace'
 gem 'redis-namespace', '>= 1.11.0'
+gem 'redis'
 gem 'redlock'
 gem 'rspec', group: :test
 gem 'rubocop', require: false, group: :test

--- a/Gemfile
+++ b/Gemfile
@@ -29,8 +29,8 @@ gem 'rack-ssl'
 gem 'rack-test', group: :test
 gem 'rake'
 gem 'rbtrace'
-gem 'redis-namespace', '>= 1.11.0'
 gem 'redis'
+gem 'redis-namespace', '>= 1.11.0'
 gem 'redlock'
 gem 'rspec', group: :test
 gem 'rubocop', require: false, group: :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1756,6 +1756,7 @@ DEPENDENCIES
   rack-test
   rake
   rbtrace
+  redis
   redis-namespace (>= 1.11.0)
   redlock
   rspec

--- a/lib/travis/logs/app/opencensus.rb
+++ b/lib/travis/logs/app/opencensus.rb
@@ -3,6 +3,7 @@
 require 'opencensus'
 require 'opencensus/stackdriver'
 require 'sequel'
+require 'redis'
 
 module Travis
   module Logs


### PR DESCRIPTION
On the production server, Opencensus is enabled, a detail that was not mirrored in the staging environment. Consequently, changes made previously failed to recognize that Redis is required as a dependency. This pull request (PR) addresses the issue by adding the Redis gem and requiring it in the Opencensus file.